### PR TITLE
Fix issue with sometimes double-updating deals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "cli-progress": "^3.9.1",
         "colors": "^1.4.0",
         "csv-stringify": "^5.6.1",
-        "deep-object-diff": "^1.1.0",
         "dice-coefficient": "^2.0.0",
         "dotenv": "^8.2.0",
         "email-providers": "^1.0.3",
@@ -1868,11 +1867,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "node_modules/deep-object-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-      "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -6416,11 +6410,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "deep-object-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
-      "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
     },
     "deepmerge": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "cli-progress": "^3.9.1",
     "colors": "^1.4.0",
     "csv-stringify": "^5.6.1",
-    "deep-object-diff": "^1.1.0",
     "dice-coefficient": "^2.0.0",
     "dotenv": "^8.2.0",
     "email-providers": "^1.0.3",

--- a/src/bin/check-licenses.ts
+++ b/src/bin/check-licenses.ts
@@ -65,7 +65,7 @@ function check(sen: string) {
 }
 
 function checkSEN(sen: string) {
-  const foundDeal = db.dealManager.getByAddonLicenseId(sen);
+  const foundDeal = db.dealManager.getByMpacId(sen);
   if (foundDeal) {
     log.info('Dev', sen, 'Already has deal:', foundDeal.id);
     return true;

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -82,7 +82,7 @@ export class ActionGenerator {
     }
     return makeCreateAction(event, event.transaction, {
       dealStage: DealStage.CLOSED_WON,
-      addonLicenseId: null,
+      addonLicenseId: event.transaction.data.addonLicenseId,
       transactionId: event.transaction.data.transactionId,
     });
   }

--- a/src/lib/engine/deal-generator/events.ts
+++ b/src/lib/engine/deal-generator/events.ts
@@ -196,10 +196,10 @@ export class EventGenerator {
 
 function abbrEventDetails(e: DealRelevantEvent) {
   switch (e.type) {
-    case 'eval': return { type: e.type, ids: e.licenses.map(l => l.data.addonLicenseId) };
-    case 'purchase': return { type: e.type, ids: e.licenses.map(l => l.data.addonLicenseId), tx: e.transaction?.data.transactionId };
-    case 'refund': return { type: e.type, ids: e.refundedTxs.map(tx => tx.data.transactionId) };
-    case 'renewal': return { type: e.type, id: e.transaction.data.transactionId };
-    case 'upgrade': return { type: e.type, id: e.transaction.data.transactionId };
+    case 'eval': return { type: e.type, ids: e.licenses.map(l => l.id) };
+    case 'purchase': return { type: e.type, ids: e.licenses.map(l => l.id), tx: e.transaction?.id };
+    case 'refund': return { type: e.type, ids: e.refundedTxs.map(tx => tx.id) };
+    case 'renewal': return { type: e.type, id: e.transaction.id };
+    case 'upgrade': return { type: e.type, id: e.transaction.id };
   }
 }

--- a/src/lib/engine/deal-generator/events.ts
+++ b/src/lib/engine/deal-generator/events.ts
@@ -194,7 +194,7 @@ export class EventGenerator {
 
 }
 
-function abbrEventDetails(e: DealRelevantEvent) {
+export function abbrEventDetails(e: DealRelevantEvent) {
   switch (e.type) {
     case 'eval': return { type: e.type, ids: e.licenses.map(l => l.id) };
     case 'purchase': return { type: e.type, ids: e.licenses.map(l => l.id), tx: e.transaction?.id };

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -41,12 +41,11 @@ export class DealGenerator {
 
     saveForInspection('ignored', this.ignoredLicenseSets);
 
-    let ignoredTotal = 0;
     for (const [reason, amount] of this.ignoredAmounts) {
-      log.info('Deal Actions', 'Amount of Transactions Ignored', { reason, amount: formatMoney(amount) });
-      ignoredTotal += amount;
+      this.db.tallier.less(reason, amount);
     }
-    log.info('Deal Actions', 'Total Amount of Transactions Ignored', formatMoney(ignoredTotal));
+    log.info('Deal Actions', 'Amount of Transactions Ignored', [...this.ignoredAmounts].map(([reason, amount]) => [reason, formatMoney(amount)]));
+
     log.warn('Deal Actions', 'Partner amounts', '\n' + [...this.partnerTransactions].map(t =>
       `  ${t.id}\t  ${t.data.saleDate}\t${t.data.vendorAmount}\t${[...new Set(getEmails(t))].join(', ')}`).join('\n'));
 

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -48,7 +48,7 @@ export class DealGenerator {
     }
     log.info('Deal Actions', 'Total Amount of Transactions Ignored', formatMoney(ignoredTotal));
     log.warn('Deal Actions', 'Partner amounts', '\n' + [...this.partnerTransactions].map(t =>
-      `  ${t.data.transactionId}\t  ${t.data.saleDate}\t${t.data.vendorAmount}\t${[...new Set(getEmails(t))].join(', ')}`).join('\n'));
+      `  ${t.id}\t  ${t.data.saleDate}\t${t.data.vendorAmount}\t${[...new Set(getEmails(t))].join(', ')}`).join('\n'));
 
     for (const { groups, properties } of this.dealCreateActions) {
       const deal = this.db.dealManager.create(properties);

--- a/src/lib/engine/deal-generator/ignore-apps.ts
+++ b/src/lib/engine/deal-generator/ignore-apps.ts
@@ -2,28 +2,34 @@ import log from "../../log/logger.js";
 import { Database } from "../../model/database.js";
 import env from "../../parameters/env.js";
 import { formatMoney, formatNumber } from "../../util/formatters.js";
+import { split } from "../../util/helpers.js";
 import { RelatedLicenseSet } from "../license-matching/license-grouper.js";
 
 export function removeIgnoredApps(db: Database, relatedLicenseSets: RelatedLicenseSet[]) {
-  removeAllFrom(db.licenses, license => license.data, "licenses");
-  removeAllFrom(db.transactions, transaction => transaction.data, "transactions");
-  removeAllFrom(relatedLicenseSets, set => set[0].license.data, "matches");
+  let ignored: number;
+
+  [db.licenses] = removeAllFrom(db.licenses, license => license.data, "licenses");
+  [db.transactions, ignored] = removeAllFrom(db.transactions, transaction => transaction.data, "transactions");
+  [relatedLicenseSets] = removeAllFrom(relatedLicenseSets, set => set[0].license.data, "matches");
+
+  db.tallier.less('Skipped archived apps', ignored);
+  log.info("Deal Generator", `Ignoring ${formatMoney(ignored)} of archived app transactions`);
+
+  return relatedLicenseSets;
 }
 
-function removeAllFrom<T>(array: T[], get: (r: T) => { addonKey: string, vendorAmount?: number }, name: string) {
-  let total = 0;
-  const before = array.length;
-  for (let i = array.length - 1; i >= 0; i--) {
-    const item = array[i];
-    const record = get(item);
-    if (hasIgnoredApp(record)) {
-      total += record.vendorAmount ?? 0;
-      array.splice(i, 1);
-    }
-  }
-  const after = array.length;
-  const totalAmountStr = total > 0 ? `(total ${formatMoney(total)})` : '';
-  log.info("Deal Generator", `Ignoring ${formatNumber(before - after)} ${name} ${totalAmountStr} leaving ${formatNumber(after)}`);
+function removeAllFrom<T>(array: T[], get: (r: T) => { addonKey: string, vendorAmount?: number }, name: string): [T[], number] {
+  const [ignored, good] = split(array, item => hasIgnoredApp(get(item)));
+
+  const totalIgnoredAmount = (ignored
+    .map(item => get(item))
+    .map(record => record.vendorAmount ?? 0)
+    .reduce((a, b) => a + b));
+
+  const totalAmountStr = totalIgnoredAmount > 0 ? `(total ${formatMoney(totalIgnoredAmount)})` : '';
+  log.info("Deal Generator", `Ignoring ${formatNumber(ignored.length)} ${name} ${totalAmountStr} leaving ${formatNumber(good.length)}`);
+
+  return [good, totalIgnoredAmount];
 }
 
 function hasIgnoredApp(record: { addonKey: string }) {

--- a/src/lib/engine/engine.ts
+++ b/src/lib/engine/engine.ts
@@ -23,13 +23,13 @@ export default class Engine {
     new ContactGenerator(db).run();
 
     log.step('Running Scoring Engine');
-    const allMatches = matchIntoLikelyGroups(db);
+    let allMatches = matchIntoLikelyGroups(db);
 
     log.step('Updating Contacts based on Match Results');
     updateContactsBasedOnMatchResults(db, allMatches);
 
     log.step('Removing ignored apps from rest of engine run');
-    removeIgnoredApps(db, allMatches);
+    allMatches = removeIgnoredApps(db, allMatches);
 
     log.step('Generating deals');
     new DealGenerator(db).run(allMatches);

--- a/src/lib/engine/summary.ts
+++ b/src/lib/engine/summary.ts
@@ -1,4 +1,5 @@
 import log from "../log/logger.js";
+import { Table } from "../log/table.js";
 import { Database } from "../model/database.js";
 import { formatMoney, formatNumber } from "../util/formatters.js";
 import { isPresent } from "../util/helpers.js";
@@ -24,22 +25,28 @@ export function printSummary(db: Database) {
     .filter(isPresent)
     .reduce((a, b) => a + b));
 
-  log.info('Summary', 'Results of this run:', {
-    'TotalDealCount': formatNumber(deals.length),
-    'TotalDealSum': formatMoney(dealSum),
+  log.info('Summary', 'Results of this run:');
 
-    'DealsCreated': formatNumber(db.dealManager.createdCount),
-    'DealsUpdated': formatNumber(db.dealManager.updatedCount),
-    'DealsAssociated': formatNumber(db.dealManager.associatedCount),
-    'DealsDisAssociated': formatNumber(db.dealManager.disassociatedCount),
+  const table = new Table(2);
 
-    'ContactsCreated': formatNumber(db.contactManager.createdCount),
-    'ContactsUpdated': formatNumber(db.contactManager.updatedCount),
-    'ContactsAssociated': formatNumber(db.contactManager.associatedCount),
-    'ContactsDisassociated': formatNumber(db.contactManager.disassociatedCount),
+  table.addRow([['Total Deal Count'], [formatNumber(deals.length), 'right']]);
+  table.addRow([['Total Deal Sum'], [formatMoney(dealSum), 'right']]);
 
-    'CompaniesUpdated': formatNumber(db.companyManager.updatedCount),
-  });
+  table.addRow([['Deals Created'], [formatNumber(db.dealManager.createdCount), 'right']]);
+  table.addRow([['Deals Updated'], [formatNumber(db.dealManager.updatedCount), 'right']]);
+  table.addRow([['Deals Associated'], [formatNumber(db.dealManager.associatedCount), 'right']]);
+  table.addRow([['Deals DisAssociated'], [formatNumber(db.dealManager.disassociatedCount), 'right']]);
+
+  table.addRow([['Contacts Created'], [formatNumber(db.contactManager.createdCount), 'right']]);
+  table.addRow([['Contacts Updated'], [formatNumber(db.contactManager.updatedCount), 'right']]);
+  table.addRow([['Contacts Associated'], [formatNumber(db.contactManager.associatedCount), 'right']]);
+  table.addRow([['Contacts Disassociated'], [formatNumber(db.contactManager.disassociatedCount), 'right']]);
+
+  table.addRow([['Companies Updated'], [formatNumber(db.companyManager.updatedCount), 'right']]);
+
+  for (const row of table.eachRow()) {
+    log.info('Summary', '  ' + row);
+  }
 
   db.tallier.less('Deal sum', dealSum);
 

--- a/src/lib/engine/summary.ts
+++ b/src/lib/engine/summary.ts
@@ -1,7 +1,5 @@
 import log from "../log/logger.js";
 import { Database } from "../model/database.js";
-import { Deal } from "../model/deal.js";
-import env from "../parameters/env.js";
 import { formatMoney, formatNumber } from "../util/formatters.js";
 import { isPresent } from "../util/helpers.js";
 
@@ -12,11 +10,11 @@ export function printSummary(db: Database) {
       'Found duplicate deals; delete them manually',
       [...db.dealManager.duplicatesToDelete].map(([dup, dupOf]) => ({
         "Primary": dupOf.size > 1
-          ? [...dupOf].map(dealLink)
+          ? [...dupOf].map(d => d.link())
           : dupOf.size === 0
             ? 'Unknown???'
-            : dealLink([...dupOf][0]),
-        "Duplicate": dealLink(dup),
+            : [...dupOf][0].link(),
+        "Duplicate": dup.link(),
       })));
   }
 
@@ -40,11 +38,4 @@ export function printSummary(db: Database) {
     'CompaniesUpdated': formatNumber(db.companyManager.updatedCount),
   });
 
-}
-
-function dealLink(deal: Deal) {
-  const hsAccountId = env.hubspot.accountId;
-  return (hsAccountId
-    ? `https://app.hubspot.com/contacts/${hsAccountId}/deal/${deal.id}/`
-    : `deal-id=${deal.id}`);
 }

--- a/src/lib/engine/summary.ts
+++ b/src/lib/engine/summary.ts
@@ -19,11 +19,14 @@ export function printSummary(db: Database) {
   }
 
   const deals = db.dealManager.getArray();
+  const dealSum = (deals
+    .map(d => d.data.amount)
+    .filter(isPresent)
+    .reduce((a, b) => a + b));
+
   log.info('Summary', 'Results of this run:', {
     'TotalDealCount': formatNumber(deals.length),
-    'TotalDealSum': formatMoney(deals.map(d => d.data.amount)
-      .filter(isPresent)
-      .reduce((a, b) => a + b)),
+    'TotalDealSum': formatMoney(dealSum),
 
     'DealsCreated': formatNumber(db.dealManager.createdCount),
     'DealsUpdated': formatNumber(db.dealManager.updatedCount),
@@ -38,4 +41,7 @@ export function printSummary(db: Database) {
     'CompaniesUpdated': formatNumber(db.companyManager.updatedCount),
   });
 
+  db.tallier.less('Deal sum', dealSum);
+
+  db.tallier.printTable();
 }

--- a/src/lib/log/table.ts
+++ b/src/lib/log/table.ts
@@ -1,0 +1,32 @@
+type Cell = [string, ('left' | 'right')?];
+type Row = Cell[];
+
+export class Table {
+
+  private rows: Row[] = [];
+
+  constructor(private colCount: number) { }
+
+  addRow(row: Cell[]) {
+    this.rows.push(row);
+  }
+
+  eachRow() {
+    const cols: number[] = [];
+    for (let i = 0; i < this.colCount; i++) {
+      cols.push(Math.max(...this.rows.map(row => row[i][0].length)));
+    }
+
+    const padders: { [key: string]: (s: string, colIdx: number) => string } = {
+      left: (s, i) => s.padEnd(cols[i], ' '),
+      right: (s, i) => s.padStart(cols[i], ' '),
+    };
+
+    return this.rows.map(row => (
+      row.map((cell, colIndex) => (
+        padders[cell[1] ?? 'left'](cell[0], colIndex)
+      )).join('  ')
+    ));
+  }
+
+}

--- a/src/lib/log/tallier.ts
+++ b/src/lib/log/tallier.ts
@@ -1,0 +1,24 @@
+import { formatMoney } from "../util/formatters.js";
+import log from "./logger.js";
+
+export class Tallier {
+
+  private tally: [string, number, number][] = [];
+  first(reason: string, n: number) { this.tally.push([reason, n, 1]); }
+  less(reason: string, n: number) { this.tally.push([reason, n, -1]); }
+
+  printTable() {
+    const remainder = (this.tally
+      .map(([reason, amount, multiplier]) => amount * multiplier)
+      .reduce((a, b) => a + b));
+
+    const rows = [...this.tally];
+    rows.push(['Unaccounted for', remainder, 0]);
+
+    const widest = Math.max(...rows.map(([reason,]) => reason.length));
+
+    log.info('Totals', 'Transaction amount flow', '\n' + rows.map(([reason, amount]) =>
+      `  ${reason.padEnd(widest, ' ')}\t${formatMoney(amount)}`).join('\n'));
+  }
+
+}

--- a/src/lib/log/tallier.ts
+++ b/src/lib/log/tallier.ts
@@ -1,5 +1,6 @@
 import { formatMoney } from "../util/formatters.js";
 import log from "./logger.js";
+import { Table } from "./table.js";
 
 export class Tallier {
 
@@ -12,13 +13,18 @@ export class Tallier {
       .map(([reason, amount, multiplier]) => amount * multiplier)
       .reduce((a, b) => a + b));
 
-    const rows = [...this.tally];
-    rows.push(['Unaccounted for', remainder, 0]);
+    const table = new Table(2);
 
-    const widest = Math.max(...rows.map(([reason,]) => reason.length));
+    for (const [reason, amount] of this.tally) {
+      table.addRow([[reason], [formatMoney(amount), 'right']]);
+    }
 
-    log.info('Totals', 'Transaction amount flow', '\n' + rows.map(([reason, amount]) =>
-      `  ${reason.padEnd(widest, ' ')}\t${formatMoney(amount)}`).join('\n'));
+    table.addRow([['Unaccounted for'], [formatMoney(remainder), 'right']]);
+
+    log.info('Totals', 'Transaction amount flow:');
+    for (const row of table.eachRow()) {
+      log.info('Totals', '  ' + row);
+    }
   }
 
 }

--- a/src/lib/model/contact.ts
+++ b/src/lib/model/contact.ts
@@ -11,7 +11,7 @@ const productsKey = env.hubspot.attrs.contact.products;
 export type ContactType = 'Partner' | 'Customer';
 
 export type ContactData = {
-  email: string;
+  readonly email: string;
   firstName: string | null;
   lastName: string | null;
   phone: string | null;

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -56,6 +56,13 @@ export class Deal extends Entity<DealData> {
     );
   }
 
+  public link() {
+    const hsAccountId = env.hubspot.accountId;
+    return (hsAccountId
+      ? `https://app.hubspot.com/contacts/${hsAccountId}/deal/${this.id}/`
+      : `deal-id=${this.id}`);
+  }
+
   override pseudoProperties: (keyof DealData)[] = [
     'hasActivity',
   ];

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -17,7 +17,7 @@ const appKey = env.hubspot.attrs.deal.app;
 export type DealData = {
   relatedProducts: string | null;
   app: string | null;
-  addonLicenseId: string | null;
+  addonLicenseId: string;
   transactionId: string | null;
   closeDate: string;
   country: string;
@@ -40,11 +40,8 @@ export class Deal extends Entity<DealData> {
     if (this.data.transactionId && this.data.addonLicenseId) {
       return `${this.data.transactionId}[${this.data.addonLicenseId}]`;
     }
-    else if (this.data.addonLicenseId) {
-      return this.data.addonLicenseId;
-    }
     else {
-      return null;
+      return this.data.addonLicenseId;
     }
   }
 
@@ -121,7 +118,7 @@ export class DealManager extends EntityManager<DealData, Deal> {
     return {
       relatedProducts: data['related_products'] || null,
       app: appKey ? data[appKey] as string : null,
-      addonLicenseId: data[addonLicenseIdKey],
+      addonLicenseId: data[addonLicenseIdKey] as string,
       transactionId: data[transactionIdKey],
       closeDate: (data['closedate'] as string).substr(0, 10),
       country: data['country'] as string,

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -36,6 +36,18 @@ export class Deal extends Entity<DealData> {
   contacts = this.makeDynamicAssociation<Contact>('contact');
   companies = this.makeDynamicAssociation<Company>('company');
 
+  mpacId() {
+    if (this.data.transactionId && this.data.addonLicenseId) {
+      return `${this.data.transactionId}[${this.data.addonLicenseId}]`;
+    }
+    else if (this.data.addonLicenseId) {
+      return this.data.addonLicenseId;
+    }
+    else {
+      return null;
+    }
+  }
+
   isEval() { return this.data.dealStage === DealStage.EVAL; }
   isClosed() {
     return (
@@ -149,20 +161,14 @@ export class DealManager extends EntityManager<DealData, Deal> {
     'transactionId',
   ];
 
-  public getByAddonLicenseId = this.makeIndex(d => [d.data.addonLicenseId].filter(isPresent), ['addonLicenseId']);
-  public getByTransactionId = this.makeIndex(d => [d.data.transactionId].filter(isPresent), ['transactionId']);
+  /** Either `License.addonLicenseId` or `Transaction.transactionId[Transacton.addonLicenseId]` */
+  public getByMpacId = this.makeIndex(d => [d.mpacId()].filter(isPresent), ['transactionId', 'addonLicenseId']);
 
   duplicatesToDelete = new Map<Deal, Set<Deal>>();
 
-  getDealsForLicenses(licenses: License[]) {
-    return new Set(licenses
-      .map(l => this.getByAddonLicenseId(l.data.addonLicenseId))
-      .filter(isPresent));
-  }
-
-  getDealsForTransactions(transactions: Transaction[]) {
-    return new Set(transactions
-      .map(tx => this.getByTransactionId(tx.data.transactionId))
+  getDealsForRecords(records: (License | Transaction)[]) {
+    return new Set(records
+      .map(record => this.getByMpacId(record.id))
       .filter(isPresent));
   }
 

--- a/src/lib/model/license.ts
+++ b/src/lib/model/license.ts
@@ -57,6 +57,8 @@ export interface LicenseData {
 
 export class License {
 
+  /** Unique ID for this License. */
+  public id: string;
   public data: LicenseData;
   public tier: number;
   public active: boolean;
@@ -114,6 +116,7 @@ export class License {
       newEvalData,
     };
 
+    this.id = this.data.addonLicenseId;
     this.tier = Math.max(this.parseTier(), this.tierFromEvalOpportunity());
     this.active = this.data.status === 'active';
   }

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -35,6 +35,8 @@ export interface TransactionData {
 
 export class Transaction {
 
+  /** Unique ID for this Transaction. */
+  public id: string;
   public data: TransactionData;
   public tier: number;
 
@@ -69,6 +71,7 @@ export class Transaction {
       vendorAmount: rawTransaction.purchaseDetails.vendorAmount,
     };
 
+    this.id = `${this.data.transactionId}--${this.data.addonLicenseId}`;
     this.tier = this.parseTier();
   }
 

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -71,7 +71,7 @@ export class Transaction {
       vendorAmount: rawTransaction.purchaseDetails.vendorAmount,
     };
 
-    this.id = `${this.data.transactionId}--${this.data.addonLicenseId}`;
+    this.id = `${this.data.transactionId}[${this.data.addonLicenseId}]`;
     this.tier = this.parseTier();
   }
 

--- a/src/lib/util/formatters.ts
+++ b/src/lib/util/formatters.ts
@@ -1,4 +1,5 @@
 export function formatNumber(n: number) {
+  if (n === 0) return '-';
   return new Intl.NumberFormat('en-US').format(n);
 }
 

--- a/src/lib/util/helpers.ts
+++ b/src/lib/util/helpers.ts
@@ -18,3 +18,13 @@ export function sorter<T>(fn: (o: T) => string | number, dir: 'ASC' | 'DSC' = 'A
     fn(a) < fn(b) ? down : up
   );
 }
+
+export function split<T>(array: T[], inFirstArray: (o: T) => boolean): [T[], T[]] {
+  const first: T[] = [];
+  const second: T[] = [];
+  for (const item of array) {
+    const which = (inFirstArray(item) ? first : second);
+    which.push(item);
+  }
+  return [first, second];
+}


### PR DESCRIPTION
This resolves #43 

- [x] Identifies deals by unique transaction + license id combination
- [x] Log (warn level) deals that are updated twice in the same engine run
- [x] Uses transaction if available when creating deal from purchase
- [x] Logging summary of transaction amount flow at end of engine run