### PR TITLE
Backfill associations

### DIFF
--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -184,6 +184,7 @@ export type UpdateDealAction = {
 
 export type NoDealAction = {
   type: 'noop';
+  groups: RelatedLicenseSet;
   deal: Deal;
 };
 
@@ -211,7 +212,7 @@ function makeUpdateAction(event: DealRelevantEvent, deal: Deal, record: License 
 
   if (!deal.hasPropertyChanges()) {
     log.detailed('Deal Actions', 'No properties to update for deal', deal.id);
-    return { type: 'noop', deal };
+    return { type: 'noop', deal, groups: event.groups };
   }
 
   return {

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -10,7 +10,7 @@ import env from '../../parameters/env.js';
 import { formatMoney } from '../../util/formatters.js';
 import { isPresent, sorter } from '../../util/helpers.js';
 import { RelatedLicenseSet } from '../license-matching/license-grouper.js';
-import { abbrActionDetails, ActionGenerator, CreateDealAction, UpdateDealAction } from './actions.js';
+import { abbrActionDetails, ActionGenerator, CreateDealAction, NoDealAction, UpdateDealAction } from './actions.js';
 import { EventGenerator } from './events.js';
 import { getEmails } from './records.js';
 
@@ -25,7 +25,7 @@ export class DealGenerator {
   private actionGenerator: ActionGenerator;
 
   private dealCreateActions: CreateDealAction[] = [];
-  private dealUpdateActions: UpdateDealAction[] = [];
+  private dealUpdateActions: (UpdateDealAction | NoDealAction)[] = [];
 
   private ignoredLicenseSets: (IgnoredLicense)[][] = [];
   private ignoredAmounts = new Map<string, number>();
@@ -113,7 +113,7 @@ export class DealGenerator {
       switch (action.type) {
         case 'create': this.dealCreateActions.push(action); break;
         case 'update': this.dealUpdateActions.push(action); break;
-        case 'noop': break;
+        case 'noop': this.dealUpdateActions.push(action); break;
       }
     }
   }

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -10,7 +10,7 @@ import env from '../../parameters/env.js';
 import { formatMoney } from '../../util/formatters.js';
 import { isPresent, sorter } from '../../util/helpers.js';
 import { RelatedLicenseSet } from '../license-matching/license-grouper.js';
-import { abbrActionDetails, ActionGenerator, CreateDealAction, NoDealAction, UpdateDealAction } from './actions.js';
+import { abbrActionDetails, ActionGenerator } from './actions.js';
 import { EventGenerator } from './events.js';
 import { getEmails } from './records.js';
 

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -24,9 +24,6 @@ export class DealGenerator {
 
   private actionGenerator: ActionGenerator;
 
-  private dealCreateActions: CreateDealAction[] = [];
-  private dealUpdateActions: (UpdateDealAction | NoDealAction)[] = [];
-
   private ignoredLicenseSets: (IgnoredLicense)[][] = [];
   private ignoredAmounts = new Map<string, number>();
 
@@ -38,7 +35,15 @@ export class DealGenerator {
 
   run(matches: RelatedLicenseSet[]) {
     for (const relatedLicenseIds of matches) {
-      this.generateActionsForMatchedGroup(relatedLicenseIds);
+      for (const action of this.generateActionsForMatchedGroup(relatedLicenseIds)) {
+        if (action.type === 'create') {
+          const deal = this.db.dealManager.create(action.properties);
+          this.associateDealContactsAndCompanies(action.groups, deal);
+        }
+        else {
+          this.associateDealContactsAndCompanies(action.groups, action.deal);
+        }
+      }
     }
 
     saveForInspection('ignored', this.ignoredLicenseSets);
@@ -49,15 +54,6 @@ export class DealGenerator {
 
     this.printIgnoredTransactionsTable();
     this.printPartnerTransactionsTable();
-
-    for (const { groups, properties } of this.dealCreateActions) {
-      const deal = this.db.dealManager.create(properties);
-      this.associateDealContactsAndCompanies(groups, deal);
-    }
-
-    for (const { deal, groups } of this.dealUpdateActions) {
-      this.associateDealContactsAndCompanies(groups, deal);
-    }
   }
 
   private printIgnoredTransactionsTable() {
@@ -103,19 +99,13 @@ export class DealGenerator {
 
   private generateActionsForMatchedGroup(groups: RelatedLicenseSet) {
     assert.ok(groups.length > 0);
-    if (this.ignoring(groups)) return;
+    if (this.ignoring(groups)) return [];
 
     const events = new EventGenerator().interpretAsEvents(groups);
     const actions = this.actionGenerator.generateFrom(events);
     log.detailed('Deal Actions', 'Generated deal actions', actions.map(action => abbrActionDetails(action)));
 
-    for (const action of actions) {
-      switch (action.type) {
-        case 'create': this.dealCreateActions.push(action); break;
-        case 'update': this.dealUpdateActions.push(action); break;
-        case 'noop': this.dealUpdateActions.push(action); break;
-      }
-    }
+    return actions;
   }
 
   private associateDealContactsAndCompanies(groups: RelatedLicenseSet, deal: Deal) {


### PR DESCRIPTION
Every event has an action generated for it. But previously, all actions that result in no upsync-able changes to an existing deal, were ignored. Now, we include those in the associate-deals-to-contacts-and-companies code. The first commit in this PR is the one that makes that change, and nothing else. The second commit just cleans up the code.

Resolves #51.