### PR TITLE
Optionally allow access token from HubSpot private app.

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -2,7 +2,8 @@
 MPAC_USER=sales@example.com
 MPAC_PASS=abc123
 MPAC_SELLER_ID=1234567
-HUBSPOT_API_KEY=6c20f2e2-96ec-48a0-b16e-7cfc86b57176
+HUBSPOT_ACCESS_TOKEN=6c20f2e2-96ec-48a0-b16e-7cfc86b57176 # use this if you make a private app
+HUBSPOT_API_KEY=6c20f2e2-96ec-48a0-b16e-7cfc86b57176      # otherwise the engine will use this
 HUBSPOT_ACCOUNT_ID=1234567 # For generating Deal links for duplicates
 
 # Get from https://api.slack.com/messaging/sending#getting_started

--- a/src/lib/io/live/hubspot.ts
+++ b/src/lib/io/live/hubspot.ts
@@ -10,7 +10,9 @@ import { HubspotService, Progress } from '../interfaces.js';
 
 export default class LiveHubspotService implements HubspotService {
 
-  client = new hubspot.Client({ apiKey: env.hubspot.apiKey });
+  client = new hubspot.Client(env.hubspot.accessToken
+    ? { accessToken: env.hubspot.accessToken }
+    : { apiKey: env.hubspot.apiKey });
 
   async downloadEntities(_progess: Progress, kind: EntityKind, apiProperties: string[], inputAssociations: string[]): Promise<FullEntity[]> {
     let associations = ((inputAssociations.length > 0)


### PR DESCRIPTION
1. When creating the app, the engine need read/write scopes for contact/deal/company (6 total).
2. There's a new key `HUBSPOT_ACCESS_TOKEN` for this, but using an API key will still work too.
3. Either `HUBSPOT_ACCESS_TOKEN` or `HUBSPOT_API_KEY` must be provided.