### PR TITLE
Don't set refunded deals to closed-won.

### DIFF
--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -198,7 +198,7 @@ As part of this phase's normalization, we also *apply* refunds to in-memory MPAC
 ##### Purchase events
 
 - Create or update deal
-- DealStage = Closed-Won
+- DealStage = Closed-Won if creating or deal was Eval
 - Set all properties
 
 ##### Renewal events

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -58,11 +58,9 @@ export class ActionGenerator {
     if (deal) this.recordSeen(deal, event);
 
     if (deal) {
-      // TODO: This should probably check for closed-lost
-      //       (i.e. refunded) and if set, avoid changing.
-      //       Or rather, update to closed-won only if eval.
       const license = event.transaction || getLatestLicense(event);
-      return makeUpdateAction(event, deal, license, DealStage.CLOSED_WON);
+      const dealStage = deal.isEval() ? DealStage.CLOSED_WON : deal.data.dealStage;
+      return makeUpdateAction(event, deal, license, dealStage);
     }
     else if (event.transaction) {
       return makeCreateAction(event, event.transaction, {


### PR DESCRIPTION
This code was possibly updating deals to closed-won when they were closed-lost. It was always closed-won before, assuming it was either an eval or a closed-won, figuring it would make no difference. But if it was refunded, it would change it from closed-lost to closed-won. This code tries to fix that, and possibly does.