### PR TITLE
Save intermediate deal generation data

### DIFF
--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -166,7 +166,7 @@ Then, for each contact in each group, we set these fields, if configured via Hub
 
 The following logic all runs on each Related License Set.
 
-During this phase, run the engine with `--loglevel=detailed` to see what events and actions are generated. (In the future, we may output them to the data/our dir also.)
+During this phase, generated events and actions are saved for inspection in data/out/deal-generator.txt. Examining this file after a local run will help make sense of what this phase is doing and how it works.
 
 #### Generating Events
 

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -1,3 +1,4 @@
+import { LogWriteStream } from '../../cache/datadir.js';
 import log from '../../log/logger.js';
 import { Deal, DealData, DealManager } from '../../model/deal.js';
 import { DealStage } from '../../model/hubspot/interfaces.js';
@@ -194,11 +195,17 @@ export type NoDealAction = {
 export type Action = CreateDealAction | UpdateDealAction | NoDealAction;
 
 export function abbrActionDetails(action: Action) {
-  switch (action.type) {
-    case 'create': return ['create', action.properties];
-    case 'update': return ['update', action.deal.id, action.properties];
-    case 'noop': return ['noop', action.deal.id];
+  const { type } = action;
+  switch (type) {
+    case 'create': return { type, data: action.properties };
+    case 'update': return { type, id: action.deal.id, data: action.properties };
+    case 'noop': return { type, id: action.deal.id };
   }
+}
+
+export function printDealActionDetails(dealGeneratorLog: LogWriteStream, actions: Action[]) {
+  dealGeneratorLog.writeLine('Actions');
+  dealGeneratorLog.writeLine(JSON.stringify(actions.map(action => abbrActionDetails(action)), null, 2));
 }
 
 function makeCreateAction(event: DealRelevantEvent, record: License | Transaction, data: Pick<DealData, 'addonLicenseId' | 'transactionId' | 'dealStage'>): Action {

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -214,7 +214,6 @@ function makeUpdateAction(event: DealRelevantEvent, deal: Deal, record: License 
   if (record) updateDeal(deal, record);
 
   if (!deal.hasPropertyChanges()) {
-    log.detailed('Deal Actions', 'No properties to update for deal', deal.id);
     return { type: 'noop', deal, groups: event.groups };
   }
 

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -11,7 +11,7 @@ import env from '../../parameters/env.js';
 import { formatMoney } from '../../util/formatters.js';
 import { isPresent, sorter } from '../../util/helpers.js';
 import { RelatedLicenseSet } from '../license-matching/license-grouper.js';
-import { abbrActionDetails, ActionGenerator } from './actions.js';
+import { ActionGenerator, printDealActionDetails } from './actions.js';
 import { EventGenerator } from './events.js';
 import { getEmails } from './records.js';
 
@@ -108,7 +108,7 @@ export class DealGenerator {
     const events = new EventGenerator(dealGeneratorLog).interpretAsEvents(groups);
     const actions = this.actionGenerator.generateFrom(events);
 
-    dealGeneratorLog.writeLine(JSON.stringify(actions.map(action => abbrActionDetails(action))));
+    printDealActionDetails(dealGeneratorLog, actions);
 
     return actions;
   }

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -35,14 +35,13 @@ export class DealGenerator {
 
   public run(matches: RelatedLicenseSet[]) {
     for (const relatedLicenseIds of matches) {
-      for (const action of this.generateActionsForMatchedGroup(relatedLicenseIds)) {
-        if (action.type === 'create') {
-          const deal = this.db.dealManager.create(action.properties);
-          this.associateDealContactsAndCompanies(action.groups, deal);
-        }
-        else {
-          this.associateDealContactsAndCompanies(action.groups, action.deal);
-        }
+      const actions = this.generateActionsForMatchedGroup(relatedLicenseIds);
+      for (const action of actions) {
+        const deal = (action.type === 'create'
+          ? this.db.dealManager.create(action.properties)
+          : action.deal);
+
+        this.associateDealContactsAndCompanies(action.groups, deal);
       }
     }
 

--- a/src/lib/engine/deal-generator/records.ts
+++ b/src/lib/engine/deal-generator/records.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as mustache from 'mustache';
-import log from '../../log/logger.js';
+import { LogWriteStream } from '../../cache/datadir.js';
 import { Table } from '../../log/table.js';
 import { Deal, DealData } from '../../model/deal.js';
 import { DealStage, Pipeline } from '../../model/hubspot/interfaces.js';
@@ -38,14 +38,14 @@ export function getLicense(addonLicenseId: string, groups: RelatedLicenseSet) {
 
 
 
-export function printRecordDetails(records: (License | Transaction)[]) {
+export function printRecordDetails(log: LogWriteStream, records: (License | Transaction)[]) {
   const ifTx = (fn: (r: Transaction) => string) =>
     (r: License | Transaction) =>
       r instanceof Transaction ? fn(r) : '';
 
-  log.detailed('Deal Actions', '\n');
+  log.writeLine('\n');
   Table.print({
-    log: str => log.detailed('Deal Actions', str),
+    log: str => log.writeLine(str),
     title: 'Records',
     rows: records,
     cols: [


### PR DESCRIPTION
This saves deal generator records, events, and actions to a file. This has three benefits:
1. It's useful for examining engine logic, to either understand it, verify it, or change it
2. It's useful for figuring out what actually happened to a deal and why
3. It's useful as a first step to sample test data (see #23); the main thing left is redacting IDs

It also was the wrong way to use the "detailed" log level, which is now unused and waiting for legitimate usage.