### PR TITLE
Redact sensitive information from deal generation data output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "got": "^11.8.3",
         "luxon": "^1.25.0",
         "mustache": "^4.2.0",
-        "source-map-support": "^0.5.21"
+        "source-map-support": "^0.5.21",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/capitalize": "^2.0.0",
@@ -32,6 +33,7 @@
         "@types/jest": "^27.0.2",
         "@types/luxon": "^1.25.1",
         "@types/mustache": "^4.1.2",
+        "@types/uuid": "^8.3.3",
         "browserslist": ">=4.16.5",
         "jest": "^27.2.5",
         "path-parse": ">=1.0.7",
@@ -1241,6 +1243,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
+      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -4313,6 +4321,15 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4882,12 +4899,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -6112,6 +6128,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
+      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
       "dev": true
     },
     "@types/yargs": {
@@ -8453,6 +8475,11 @@
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -8860,9 +8887,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-to-istanbul": {
       "version": "8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "burner-email-providers": "^1.0.42",
         "capitalize": "^2.0.3",
         "chalk": "^4.1.2",
+        "chance": "^1.1.8",
         "cli-progress": "^3.9.1",
         "csv-stringify": "^5.6.1",
         "dotenv": "^8.2.0",
@@ -23,17 +24,16 @@
         "got": "^11.8.3",
         "luxon": "^1.25.0",
         "mustache": "^4.2.0",
-        "source-map-support": "^0.5.21",
-        "uuid": "^8.3.2"
+        "source-map-support": "^0.5.21"
       },
       "devDependencies": {
         "@types/capitalize": "^2.0.0",
+        "@types/chance": "^1.1.3",
         "@types/cli-progress": "^3.9.2",
         "@types/flat": "^5.0.1",
         "@types/jest": "^27.0.2",
         "@types/luxon": "^1.25.1",
         "@types/mustache": "^4.1.2",
-        "@types/uuid": "^8.3.3",
         "browserslist": ">=4.16.5",
         "jest": "^27.2.5",
         "path-parse": ">=1.0.7",
@@ -1124,6 +1124,12 @@
       "integrity": "sha512-Jxz08Zch+/J+R3DUcPGmXZ4hNzZImd/FXXij32ByTfclrCQr15+geQjV5teTyFQb3zYPi7O5pRv2/YsyDfRmjA==",
       "dev": true
     },
+    "node_modules/@types/chance": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chance/-/chance-1.1.3.tgz",
+      "integrity": "sha512-X6c6ghhe4/sQh4XzcZWSFaTAUOda38GQHmq9BUanYkOE/EO7ZrkazwKmtsj3xzTjkLWmwULE++23g3d3CCWaWw==",
+      "dev": true
+    },
     "node_modules/@types/cli-progress": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.9.2.tgz",
@@ -1243,12 +1249,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
-      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -1731,6 +1731,11 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chance": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.8.tgz",
+      "integrity": "sha512-v7fi5Hj2VbR6dJEGRWLmJBA83LJMS47pkAbmROFxHWd9qmE1esHRZW8Clf1Fhzr3rjxnNZVCjOEv/ivFxeIMtg=="
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -4898,14 +4903,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
@@ -6009,6 +6006,12 @@
       "integrity": "sha512-Jxz08Zch+/J+R3DUcPGmXZ4hNzZImd/FXXij32ByTfclrCQr15+geQjV5teTyFQb3zYPi7O5pRv2/YsyDfRmjA==",
       "dev": true
     },
+    "@types/chance": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/chance/-/chance-1.1.3.tgz",
+      "integrity": "sha512-X6c6ghhe4/sQh4XzcZWSFaTAUOda38GQHmq9BUanYkOE/EO7ZrkazwKmtsj3xzTjkLWmwULE++23g3d3CCWaWw==",
+      "dev": true
+    },
     "@types/cli-progress": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.9.2.tgz",
@@ -6128,12 +6131,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
-      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
       "dev": true
     },
     "@types/yargs": {
@@ -6509,6 +6506,11 @@
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       }
+    },
+    "chance": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.8.tgz",
+      "integrity": "sha512-v7fi5Hj2VbR6dJEGRWLmJBA83LJMS47pkAbmROFxHWd9qmE1esHRZW8Clf1Fhzr3rjxnNZVCjOEv/ivFxeIMtg=="
     },
     "char-regex": {
       "version": "1.0.2",
@@ -8885,11 +8887,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-to-istanbul": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "got": "^11.8.3",
     "luxon": "^1.25.0",
     "mustache": "^4.2.0",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/capitalize": "^2.0.0",
@@ -37,6 +38,7 @@
     "@types/jest": "^27.0.2",
     "@types/luxon": "^1.25.1",
     "@types/mustache": "^4.1.2",
+    "@types/uuid": "^8.3.3",
     "browserslist": ">=4.16.5",
     "jest": "^27.2.5",
     "path-parse": ">=1.0.7",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "burner-email-providers": "^1.0.42",
     "capitalize": "^2.0.3",
     "chalk": "^4.1.2",
+    "chance": "^1.1.8",
     "cli-progress": "^3.9.1",
     "csv-stringify": "^5.6.1",
     "dotenv": "^8.2.0",
@@ -28,17 +29,16 @@
     "got": "^11.8.3",
     "luxon": "^1.25.0",
     "mustache": "^4.2.0",
-    "source-map-support": "^0.5.21",
-    "uuid": "^8.3.2"
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@types/capitalize": "^2.0.0",
+    "@types/chance": "^1.1.3",
     "@types/cli-progress": "^3.9.2",
     "@types/flat": "^5.0.1",
     "@types/jest": "^27.0.2",
     "@types/luxon": "^1.25.1",
     "@types/mustache": "^4.1.2",
-    "@types/uuid": "^8.3.3",
     "browserslist": ">=4.16.5",
     "jest": "^27.2.5",
     "path-parse": ">=1.0.7",

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -194,20 +194,6 @@ export type NoDealAction = {
 
 export type Action = CreateDealAction | UpdateDealAction | NoDealAction;
 
-export function abbrActionDetails(action: Action) {
-  const { type } = action;
-  switch (type) {
-    case 'create': return { type, data: action.properties };
-    case 'update': return { type, id: action.deal.id, data: action.properties };
-    case 'noop': return { type, id: action.deal.id };
-  }
-}
-
-export function printDealActionDetails(dealGeneratorLog: LogWriteStream, actions: Action[]) {
-  dealGeneratorLog.writeLine('Actions');
-  dealGeneratorLog.writeLine(JSON.stringify(actions.map(action => abbrActionDetails(action)), null, 2));
-}
-
 function makeCreateAction(event: DealRelevantEvent, record: License | Transaction, data: Pick<DealData, 'addonLicenseId' | 'transactionId' | 'dealStage'>): Action {
   return {
     type: 'create',

--- a/src/lib/engine/deal-generator/events.ts
+++ b/src/lib/engine/deal-generator/events.ts
@@ -191,10 +191,10 @@ export class EventGenerator {
 
 export function abbrEventDetails(e: DealRelevantEvent) {
   switch (e.type) {
-    case 'eval': return { type: e.type, lics: e.licenses.map(l => l.id) };
+    case 'eval': return { type: e.type, lics: e.licenses.map(l => l.id), txs: [] };
     case 'purchase': return { type: e.type, lics: e.licenses.map(l => l.id), txs: [e.transaction?.id] };
-    case 'refund': return { type: e.type, txs: e.refundedTxs.map(tx => tx.id) };
-    case 'renewal': return { type: e.type, txs: [e.transaction.id] };
-    case 'upgrade': return { type: e.type, txs: [e.transaction.id] };
+    case 'refund': return { type: e.type, lics: [], txs: e.refundedTxs.map(tx => tx.id) };
+    case 'renewal': return { type: e.type, lics: [], txs: [e.transaction.id] };
+    case 'upgrade': return { type: e.type, lics: [], txs: [e.transaction.id] };
   }
 }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -1,0 +1,70 @@
+import DataDir from "../../cache/datadir.js";
+import { Table } from "../../log/table.js";
+import { License } from "../../model/license.js";
+import { Transaction } from "../../model/transaction.js";
+import { formatMoney } from "../../util/formatters.js";
+import { Action } from "./actions.js";
+import { abbrEventDetails, DealRelevantEvent } from "./events.js";
+
+export class DealDataLogger {
+
+  plainLog = DataDir.out.file('deal-generator.txt').writeStream();
+  rededLog = DataDir.out.file('deal-generator-redacted.txt').writeStream();
+
+  close() {
+    this.plainLog.close();
+    this.rededLog.close();
+  }
+
+  logActions(actions: Action[]) {
+    this.plainLog.writeLine('Actions');
+    this.plainLog.writeLine(JSON.stringify(actions.map(action => abbrActionDetails(action)), null, 2));
+  }
+
+  logRecords(records: (License | Transaction)[]) {
+    const ifTx = (fn: (r: Transaction) => string) =>
+      (r: License | Transaction) =>
+        r instanceof Transaction ? fn(r) : '';
+
+    this.plainLog.writeLine('\n');
+    Table.print({
+      log: str => this.plainLog.writeLine(str),
+      title: 'Records',
+      rows: records,
+      cols: [
+        [{ title: 'Hosting' }, record => record.data.hosting],
+        [{ title: 'AddonLicenseId' }, record => record.data.addonLicenseId],
+        [{ title: 'Date' }, record => record.data.maintenanceStartDate],
+        [{ title: 'LicenseType' }, record => record.data.licenseType],
+        [{ title: 'SaleType' }, ifTx(record => record.data.saleType)],
+        [{ title: 'Transaction' }, ifTx(record => record.data.transactionId)],
+        [{ title: 'Amount', align: 'right' }, ifTx(record => formatMoney(record.data.vendorAmount))],
+      ],
+    });
+  }
+
+  logEvents(events: DealRelevantEvent[]) {
+    const rows = events.map(abbrEventDetails);
+
+    Table.print({
+      title: 'Events',
+      log: str => this.plainLog.writeLine(str),
+      rows: rows,
+      cols: [
+        [{ title: 'Type' }, row => row.type],
+        [{ title: 'Licenses' }, row => row.lics?.join(', ') ?? ''],
+        [{ title: 'Transactions' }, row => row.txs?.join(', ') ?? ''],
+      ],
+    });
+  }
+
+}
+
+function abbrActionDetails(action: Action) {
+  const { type } = action;
+  switch (type) {
+    case 'create': return { type, data: action.properties };
+    case 'update': return { type, id: action.deal.id, data: action.properties };
+    case 'noop': return { type, id: action.deal.id };
+  }
+}

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import Chance from 'chance';
 import DataDir, { LogWriteStream } from "../../cache/datadir.js";
 import { Table } from "../../log/table.js";
 import { DealData } from "../../model/deal.js";
@@ -151,6 +151,8 @@ class NonRedactor implements Redactor {
 
 class PrivacyRedactor implements Redactor {
 
+  private chance = new Chance();
+
   private redactions = new Map<string, string>();
   private newIds = new Set<string>();
 
@@ -167,7 +169,13 @@ class PrivacyRedactor implements Redactor {
   }
 
   private shortUUID() {
-    return uuidv4().replace(/-/g, '').slice(0, 10);
+    return this.chance.string({
+      length: 10,
+      alpha: true,
+      numeric: true,
+      symbols: false,
+      casing: 'lower'
+    });
   }
 
   public addonLicenseId<T extends R>(val: T): T {
@@ -183,15 +191,15 @@ class PrivacyRedactor implements Redactor {
   }
 
   public appName<T extends R>(val: T): T {
-    return this.redact(val, () => `AppName[${this.shortUUID()}]`);
+    return this.redact(val, () => `AppName[${this.chance.word({ capitalize: true, syllables: 2 })}]`);
   }
 
   public dealName<T extends R>(val: T): T {
-    return this.redact(val, () => `DealName[${this.shortUUID()}]`);
+    return this.redact(val, () => `DealName[${this.chance.word({ capitalize: true, syllables: 2 })}]`);
   }
 
   public product<T extends R>(val: T): T {
-    return this.redact(val, () => `Product[${this.shortUUID()}]`);
+    return this.redact(val, () => `Product[${this.chance.word({ capitalize: true, syllables: 2 })}]`);
   }
 
 }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -8,26 +8,22 @@ import { formatMoney } from "../../util/formatters.js";
 import { Action } from "./actions.js";
 import { abbrEventDetails, DealRelevantEvent } from "./events.js";
 
-type RedactIdFn = <T extends string | undefined | null>(prefix: string, id: T) => T;
-
-const sameId = <T extends string | undefined | null>(prefix: string, x: T) => x;
-
 const dealPropertyRedactors: {
-  [K in keyof DealData]: (redact: RedactIdFn, val: Partial<DealData>[K]) => Partial<DealData>[K]
+  [K in keyof DealData]: (redact: Redactor, val: Partial<DealData>[K]) => Partial<DealData>[K]
 } = {
-  addonLicenseId: (redact, addonLicenseId) => redact('L_', addonLicenseId),
+  addonLicenseId: (redact, addonLicenseId) => redact.addonLicenseId(addonLicenseId),
   amount: (redact, amount) => amount,
-  app: (redact, app) => redact('App:', app),
+  app: (redact, app) => redact.appName(app),
   closeDate: (redact, closeDate) => closeDate,
   country: (redact, country) => country,
-  dealName: (redact, dealName) => redact('DealName:', dealName),
+  dealName: (redact, dealName) => redact.dealName(dealName),
   dealStage: (redact, dealStage) => dealStage,
   deployment: (redact, deployment) => deployment,
   licenseTier: (redact, licenseTier) => licenseTier,
   origin: (redact, origin) => origin,
   pipeline: (redact, pipeline) => pipeline,
-  relatedProducts: (redact, relatedProducts) => redact('RelatedProducts:', relatedProducts),
-  transactionId: (redact, transactionId) => redact('TX_', transactionId),
+  relatedProducts: (redact, relatedProducts) => redact.product(relatedProducts),
+  transactionId: (redact, transactionId) => redact.transactionId(transactionId),
 };
 
 export class DealDataLogger {
@@ -35,43 +31,29 @@ export class DealDataLogger {
   plainLog = DataDir.out.file('deal-generator.txt').writeStream();
   rededLog = DataDir.out.file('deal-generator-redacted.txt').writeStream();
 
-  redactions = new Map<string, string>();
-  newIds = new Set<string>();
+  nonRedactor = new NonRedactor();
+  shhRedactor = new PrivacyRedactor();
 
   close() {
     this.plainLog.close();
     this.rededLog.close();
   }
 
-  redact<T extends string | undefined | null>(prefix: string, id: T): T {
-    if (id === undefined || id === null) return id;
-
-    let rid = this.redactions.get(id);
-    if (!rid) {
-      do { rid = prefix + uuidv4().replace(/-/g, '').slice(0, 10); }
-      while (this.newIds.has(rid));
-      this.newIds.add(rid);
-      this.redactions.set(id, rid)
-    };
-    return rid as T;
-  }
-
   logActions(actions: Action[]) {
-    const redact = this.redact.bind(this);
-    this._logActions(this.plainLog, sameId, actions);
-    this._logActions(this.rededLog, redact, actions);
+    this._logActions(this.plainLog, this.nonRedactor, actions);
+    this._logActions(this.rededLog, this.shhRedactor, actions);
   }
 
-  printDealProperties(log: LogWriteStream, redact: RedactIdFn, data: Partial<DealData>) {
+  printDealProperties(log: LogWriteStream, redact: Redactor, data: Partial<DealData>) {
     for (const [k, v] of Object.entries(data)) {
       const key = k as keyof DealData;
-      const fn = dealPropertyRedactors[key] as <T>(redact: RedactIdFn, val: T) => T;
+      const fn = dealPropertyRedactors[key] as <T>(redact: Redactor, val: T) => T;
       const val = fn(redact, v);
       log.writeLine(`    ${k}: ${val}`);
     }
   }
 
-  private _logActions(log: LogWriteStream, redact: RedactIdFn, actions: Action[]) {
+  private _logActions(log: LogWriteStream, redact: Redactor, actions: Action[]) {
     log.writeLine('Actions');
     for (const action of actions) {
       switch (action.type) {
@@ -80,23 +62,22 @@ export class DealDataLogger {
           this.printDealProperties(log, redact, action.properties);
           break;
         case 'update':
-          log.writeLine(`  Update: ${redact('D_', action.deal.id)}`);
+          log.writeLine(`  Update: ${redact.dealId(action.deal.id)}`);
           this.printDealProperties(log, redact, action.properties);
           break;
         case 'noop':
-          log.writeLine(`  Nothing: ${redact('D_', action.deal.id)}`);
+          log.writeLine(`  Nothing: ${redact.dealId(action.deal.id)}`);
           break;
       }
     }
   }
 
   logRecords(records: (License | Transaction)[]) {
-    const redact = this.redact.bind(this);
-    this._logRecords(this.plainLog, sameId, records);
-    this._logRecords(this.rededLog, redact, records);
+    this._logRecords(this.plainLog, this.nonRedactor, records);
+    this._logRecords(this.rededLog, this.shhRedactor, records);
   }
 
-  private _logRecords(log: LogWriteStream, redact: RedactIdFn, records: (License | Transaction)[]) {
+  private _logRecords(log: LogWriteStream, redact: Redactor, records: (License | Transaction)[]) {
     const ifTx = (fn: (r: Transaction) => string) =>
       (r: License | Transaction) =>
         r instanceof Transaction ? fn(r) : '';
@@ -108,27 +89,26 @@ export class DealDataLogger {
       rows: records,
       cols: [
         [{ title: 'Hosting' }, record => record.data.hosting],
-        [{ title: 'AddonLicenseId' }, record => redact('L_', record.data.addonLicenseId)],
+        [{ title: 'AddonLicenseId' }, record => redact.addonLicenseId(record.data.addonLicenseId)],
         [{ title: 'Date' }, record => record.data.maintenanceStartDate],
         [{ title: 'LicenseType' }, record => record.data.licenseType],
         [{ title: 'SaleType' }, ifTx(record => record.data.saleType)],
-        [{ title: 'Transaction' }, ifTx(record => redact('TX_', record.data.transactionId))],
+        [{ title: 'Transaction' }, ifTx(record => redact.transactionId(record.data.transactionId))],
         [{ title: 'Amount', align: 'right' }, ifTx(record => formatMoney(record.data.vendorAmount))],
       ],
     });
   }
 
   logEvents(events: DealRelevantEvent[]) {
-    const redact = this.redact.bind(this);
-    this._logEvents(this.plainLog, sameId, events);
-    this._logEvents(this.rededLog, redact, events);
+    this._logEvents(this.plainLog, this.nonRedactor, events);
+    this._logEvents(this.rededLog, this.shhRedactor, events);
   }
 
-  private _logEvents(log: LogWriteStream, redact: RedactIdFn, events: DealRelevantEvent[]) {
+  private _logEvents(log: LogWriteStream, redact: Redactor, events: DealRelevantEvent[]) {
     const rows = events.map(abbrEventDetails).map(({ type, lics, txs }) => ({
       type,
-      lics: lics.map(l => redact('L_', l)),
-      txs: txs.map(tx => redact('TX_', tx)),
+      lics: lics.map(l => redact.addonLicenseId(l)),
+      txs: txs.map(tx => redact.transactionId(tx)),
     }));
 
     Table.print({
@@ -141,6 +121,77 @@ export class DealDataLogger {
         [{ title: 'Transactions' }, row => row.txs?.join(', ') ?? ''],
       ],
     });
+  }
+
+}
+
+type R = string | undefined | null;
+
+interface Redactor {
+
+  addonLicenseId<T extends R>(val: T): T;
+  transactionId<T extends R>(val: T): T;
+  dealId<T extends R>(val: T): T;
+  appName<T extends R>(val: T): T;
+  dealName<T extends R>(val: T): T;
+  product<T extends R>(val: T): T;
+
+}
+
+class NonRedactor implements Redactor {
+
+  public addonLicenseId<T extends R>(val: T): T { return val; }
+  public transactionId<T extends R>(val: T): T { return val; }
+  public dealId<T extends R>(val: T): T { return val; }
+  public appName<T extends R>(val: T): T { return val; }
+  public dealName<T extends R>(val: T): T { return val; }
+  public product<T extends R>(val: T): T { return val; }
+
+}
+
+class PrivacyRedactor implements Redactor {
+
+  private redactions = new Map<string, string>();
+  private newIds = new Set<string>();
+
+  private redact<T extends R>(id: T, idgen: () => string): T {
+    if (id === undefined || id === null) return id;
+    let rid = this.redactions.get(id);
+    if (!rid) {
+      do { rid = idgen(); }
+      while (this.newIds.has(rid));
+      this.newIds.add(rid);
+      this.redactions.set(id, rid)
+    };
+    return rid as T;
+  }
+
+  private shortUUID() {
+    return uuidv4().replace(/-/g, '').slice(0, 10);
+  }
+
+  public addonLicenseId<T extends R>(val: T): T {
+    return this.redact(val, () => `L[${this.shortUUID()}]`);
+  }
+
+  public transactionId<T extends R>(val: T): T {
+    return this.redact(val, () => `TX[${this.shortUUID()}]`);
+  }
+
+  public dealId<T extends R>(val: T): T {
+    return this.redact(val, () => `D[${this.shortUUID()}]`);
+  }
+
+  public appName<T extends R>(val: T): T {
+    return this.redact(val, () => `AppName[${this.shortUUID()}]`);
+  }
+
+  public dealName<T extends R>(val: T): T {
+    return this.redact(val, () => `DealName[${this.shortUUID()}]`);
+  }
+
+  public product<T extends R>(val: T): T {
+    return this.redact(val, () => `Product[${this.shortUUID()}]`);
   }
 
 }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -1,35 +1,55 @@
-import DataDir from "../../cache/datadir.js";
+import DataDir, { LogWriteStream } from "../../cache/datadir.js";
 import { Table } from "../../log/table.js";
 import { License } from "../../model/license.js";
 import { Transaction } from "../../model/transaction.js";
 import { formatMoney } from "../../util/formatters.js";
 import { Action } from "./actions.js";
 import { abbrEventDetails, DealRelevantEvent } from "./events.js";
+import { v4 as uuidv4 } from "uuid";
+
+type RedactIdFn = <T extends string | undefined>(id: T) => T;
+
+const sameId = <T extends string | undefined>(x: T) => x;
 
 export class DealDataLogger {
 
   plainLog = DataDir.out.file('deal-generator.txt').writeStream();
   rededLog = DataDir.out.file('deal-generator-redacted.txt').writeStream();
 
+  redactions = new Map<string, string>();
+  newIds = new Set<string>();
+
   close() {
     this.plainLog.close();
     this.rededLog.close();
   }
 
-  logActions(actions: Action[]) {
-    this._logActions(false, actions);
-    this._logActions(true, actions);
+  redact<T extends string | undefined>(id: T): T {
+    if (typeof id === 'undefined') return id;
+
+    let rid = this.redactions.get(id);
+    if (!rid) {
+      do { rid = uuidv4().replace(/-/g, '').slice(0, 10); }
+      while (this.newIds.has(rid));
+      this.newIds.add(rid);
+      this.redactions.set(id, rid)
+    };
+    return rid as T;
   }
 
-  private _logActions(redacted: boolean, actions: Action[]) {
-    const log = this.loggerFor(redacted);
+  logActions(actions: Action[]) {
+    const redact = this.redact.bind(this);
+    this._logActions(this.plainLog, sameId, actions);
+    this._logActions(this.rededLog, redact, actions);
+  }
 
+  private _logActions(log: LogWriteStream, redact: RedactIdFn, actions: Action[]) {
     function abbrActionDetails(action: Action) {
       const { type } = action;
       switch (type) {
         case 'create': return { type, data: action.properties };
-        case 'update': return { type, id: action.deal.id, data: action.properties };
-        case 'noop': return { type, id: action.deal.id };
+        case 'update': return { type, id: redact(action.deal.id), data: action.properties };
+        case 'noop': return { type, id: redact(action.deal.id) };
       }
     }
 
@@ -38,13 +58,12 @@ export class DealDataLogger {
   }
 
   logRecords(records: (License | Transaction)[]) {
-    this._logRecords(false, records);
-    this._logRecords(true, records);
+    const redact = this.redact.bind(this);
+    this._logRecords(this.plainLog, sameId, records);
+    this._logRecords(this.rededLog, redact, records);
   }
 
-  private _logRecords(redacted: boolean, records: (License | Transaction)[]) {
-    const log = this.loggerFor(redacted);
-
+  private _logRecords(log: LogWriteStream, redact: RedactIdFn, records: (License | Transaction)[]) {
     const ifTx = (fn: (r: Transaction) => string) =>
       (r: License | Transaction) =>
         r instanceof Transaction ? fn(r) : '';
@@ -56,25 +75,28 @@ export class DealDataLogger {
       rows: records,
       cols: [
         [{ title: 'Hosting' }, record => record.data.hosting],
-        [{ title: 'AddonLicenseId' }, record => record.data.addonLicenseId],
+        [{ title: 'AddonLicenseId' }, record => redact(record.data.addonLicenseId)],
         [{ title: 'Date' }, record => record.data.maintenanceStartDate],
         [{ title: 'LicenseType' }, record => record.data.licenseType],
         [{ title: 'SaleType' }, ifTx(record => record.data.saleType)],
-        [{ title: 'Transaction' }, ifTx(record => record.data.transactionId)],
+        [{ title: 'Transaction' }, ifTx(record => redact(record.data.transactionId))],
         [{ title: 'Amount', align: 'right' }, ifTx(record => formatMoney(record.data.vendorAmount))],
       ],
     });
   }
 
   logEvents(events: DealRelevantEvent[]) {
-    this._logEvents(false, events);
-    this._logEvents(true, events);
+    const redact = this.redact.bind(this);
+    this._logEvents(this.plainLog, sameId, events);
+    this._logEvents(this.rededLog, redact, events);
   }
 
-  private _logEvents(redacted: boolean, events: DealRelevantEvent[]) {
-    const log = this.loggerFor(redacted);
-
-    const rows = events.map(abbrEventDetails);
+  private _logEvents(log: LogWriteStream, redact: RedactIdFn, events: DealRelevantEvent[]) {
+    const rows = events.map(abbrEventDetails).map(({ type, lics, txs }) => ({
+      type,
+      lics: lics.map(redact),
+      txs: txs.map(redact),
+    }));
 
     Table.print({
       title: 'Events',
@@ -86,13 +108,6 @@ export class DealDataLogger {
         [{ title: 'Transactions' }, row => row.txs?.join(', ') ?? ''],
       ],
     });
-  }
-
-  private loggerFor(redacted: boolean) {
-    if (redacted)
-      return this.rededLog;
-    else
-      return this.plainLog;
   }
 
 }

--- a/src/lib/engine/deal-generator/records.ts
+++ b/src/lib/engine/deal-generator/records.ts
@@ -1,13 +1,10 @@
 import * as assert from 'assert';
 import * as mustache from 'mustache';
-import { LogWriteStream } from '../../cache/datadir.js';
-import { Table } from '../../log/table.js';
 import { Deal, DealData } from '../../model/deal.js';
 import { DealStage, Pipeline } from '../../model/hubspot/interfaces.js';
 import { License } from '../../model/license.js';
 import { Transaction } from '../../model/transaction.js';
 import env from '../../parameters/env.js';
-import { formatMoney } from '../../util/formatters.js';
 import { isPresent, sorter } from "../../util/helpers.js";
 import { RelatedLicenseSet } from '../license-matching/license-grouper.js';
 
@@ -34,30 +31,6 @@ export function getLicense(addonLicenseId: string, groups: RelatedLicenseSet) {
     .find(l => l.data.addonLicenseId === addonLicenseId));
   assert.ok(license);
   return license;
-}
-
-
-
-export function printRecordDetails(log: LogWriteStream, records: (License | Transaction)[]) {
-  const ifTx = (fn: (r: Transaction) => string) =>
-    (r: License | Transaction) =>
-      r instanceof Transaction ? fn(r) : '';
-
-  log.writeLine('\n');
-  Table.print({
-    log: str => log.writeLine(str),
-    title: 'Records',
-    rows: records,
-    cols: [
-      [{ title: 'Hosting' }, record => record.data.hosting],
-      [{ title: 'AddonLicenseId' }, record => record.data.addonLicenseId],
-      [{ title: 'Date' }, record => record.data.maintenanceStartDate],
-      [{ title: 'LicenseType' }, record => record.data.licenseType],
-      [{ title: 'SaleType' }, ifTx(record => record.data.saleType)],
-      [{ title: 'Transaction' }, ifTx(record => record.data.transactionId)],
-      [{ title: 'Amount', align: 'right' }, ifTx(record => formatMoney(record.data.vendorAmount))],
-    ],
-  });
 }
 
 export function dealCreationProperties(record: License | Transaction, data: Pick<DealData, 'addonLicenseId' | 'transactionId' | 'dealStage'>): DealData {


### PR DESCRIPTION
1. Prints generated deal-actions in nicer format for manual inspection (instead of just JSON)
2. Redacts all IDs, amounts, and identifying info from generated output

This should help create realistic test cases for #23 using real data but with redacted information.