### PR TITLE
Add dev-container for consistent dev experience.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/javascript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT="16-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/javascript-node
+{
+	"name": "Node.js",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "16-bullseye"
+		}
+	},
+	"extensions": [
+		"mikestead.dotenv",
+		"yzhang.markdown-all-in-one",
+		"mechatroner.rainbow-csv"
+	],
+	// "forwardPorts": [],
+	"postCreateCommand": "npm i",
+	"remoteUser": "node",
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/javascript-node
 {
-	"name": "Node.js",
+	"name": "Marketing Automation Engine",
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {


### PR DESCRIPTION
1. Makes it much easier for other devs to clone this repo into a fully-ready dev environment
2. Makes sure the project's Node version doesn't clash with any dev's local node version
3. Allows devs to avoid even having Node set up locally, they just need VS Code
4. Installs a few project-specific VS Code extensions for you (questionably used here)
5. If you don't use Docker or VS Code, these config files have no negative impact, and the project still works

This could be a useful pattern for more projects. @khanguyen88 what do you think?