### PR TITLE
Generate test data

### DIFF
--- a/src/lib/engine/deal-generator/events.ts
+++ b/src/lib/engine/deal-generator/events.ts
@@ -191,10 +191,10 @@ export class EventGenerator {
 
 export function abbrEventDetails(e: DealRelevantEvent) {
   switch (e.type) {
-    case 'eval': return { type: e.type, lics: e.licenses.map(l => l.id), txs: [] };
+    case 'eval': return { type: e.type, lics: e.licenses.map(l => l.id) };
     case 'purchase': return { type: e.type, lics: e.licenses.map(l => l.id), txs: [e.transaction?.id] };
-    case 'refund': return { type: e.type, lics: [], txs: e.refundedTxs.map(tx => tx.id) };
-    case 'renewal': return { type: e.type, lics: [], txs: [e.transaction.id] };
-    case 'upgrade': return { type: e.type, lics: [], txs: [e.transaction.id] };
+    case 'refund': return { type: e.type, txs: e.refundedTxs.map(tx => tx.id) };
+    case 'renewal': return { type: e.type, txs: [e.transaction.id] };
+    case 'upgrade': return { type: e.type, txs: [e.transaction.id] };
   }
 }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -240,7 +240,7 @@ class PrivacyRedactor implements Redactor {
   }
 
   public amount<T extends R>(val: T): T {
-    return this.redact(val, () => this.chance.floating({ min: 0, max: 100_000 }));
+    return this.redact(val, () => this.chance.floating({ min: 0, max: 1000 }));
   }
 
 }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -227,7 +227,7 @@ class PrivacyRedactor implements Redactor {
   }
 
   public amount<T extends R>(val: T): T {
-    return this.redact(val, () => this.chance.floating({ min: 0, max: 1_000 }));
+    return this.redact(val, () => this.chance.floating({ min: 0, max: 100_000 }));
   }
 
 }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -240,7 +240,7 @@ class PrivacyRedactor implements Redactor {
   }
 
   public amount<T extends R>(val: T): T {
-    return this.redact(val, () => this.chance.floating({ min: 0, max: 1000 }), false);
+    return this.redact(val, () => this.chance.integer({ min: 0, max: 1000 }), false);
   }
 
 }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -57,17 +57,31 @@ export class FileDealDataLogger {
     this.log.writeLine('Actions');
     for (const action of actions) {
       switch (action.type) {
-        case 'create':
+        case 'create': {
           this.log.writeLine('  Create:');
           this.printDealProperties(action.properties);
           break;
-        case 'update':
-          this.log.writeLine(`  Update: ${this.redact.dealId(action.deal.id)}`);
+        }
+        case 'update': {
+          const dealId = this.redact.dealId(action.deal.id);
+          this.log.writeLine(`  Update: ${dealId}`);
           this.printDealProperties(action.properties);
           break;
-        case 'noop':
-          this.log.writeLine(`  Nothing: ${this.redact.dealId(action.deal.id)}`);
+        }
+        case 'noop': {
+          const dealId = this.redact.dealId(action.deal.id);
+          const recordId = (action.deal.data.transactionId
+            ? this.redactedTransaction({
+              data: {
+                transactionId: action.deal.data.transactionId,
+                addonLicenseId: action.deal.data.addonLicenseId,
+              }
+            })
+            : this.redact.addonLicenseId(action.deal.data.addonLicenseId)
+          );
+          this.log.writeLine(`  Nothing: ${dealId} (via ${recordId})`);
           break;
+        }
       }
     }
   }
@@ -146,7 +160,7 @@ export class FileDealDataLogger {
     });
   }
 
-  private redactedTransaction(transaction: Transaction | undefined) {
+  private redactedTransaction(transaction: { data: { transactionId: string, addonLicenseId: string } } | undefined) {
     if (!transaction) return undefined;
     const transactionId = this.redact.transactionId(transaction.data.transactionId);
     const addonLicenseId = this.redact.addonLicenseId(transaction.data.addonLicenseId);

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -71,11 +71,12 @@ export class FileDealDataLogger {
         }
         case 'noop': {
           const dealId = this.redact.dealId(action.deal.id);
-          const { amount, addonLicenseId, transactionId, dealStage } = action.deal.data;
+          const { amount: realAmount, addonLicenseId, transactionId, dealStage } = action.deal.data;
           const recordId = (transactionId
             ? this.redactedTransaction({ transactionId, addonLicenseId })
             : this.redact.addonLicenseId(addonLicenseId)
           );
+          const amount = this.redact.amount(realAmount);
           const stage = DealStage[dealStage];
           this.log.writeLine(`  Nothing: ${dealId}, via ${recordId}, stage=${stage}, amount=${amount}`);
           break;

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -202,7 +202,7 @@ class PrivacyRedactor implements Redactor {
   private newIds = new Set<string | number>();
 
   private redact<T extends R>(id: T, idgen: () => string | number, mustBeUnique = true): T {
-    if (id === undefined || id === null) return id;
+    if (id === undefined || id === null || id === 0) return id;
     let rid = this.redactions.get(id);
     if (!rid) {
       do { rid = idgen(); }
@@ -240,7 +240,7 @@ class PrivacyRedactor implements Redactor {
   }
 
   public amount<T extends R>(val: T): T {
-    return this.redact(val, () => this.chance.integer({ min: 0, max: 1000 }), false);
+    return this.redact(val, () => this.chance.integer({ min: 1, max: 1000 }), false);
   }
 
 }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -8,24 +8,6 @@ import { formatMoney } from "../../util/formatters.js";
 import { Action } from "./actions.js";
 import { DealRelevantEvent } from "./events.js";
 
-const dealPropertyRedactors: {
-  [K in keyof DealData]: (redact: Redactor, val: Partial<DealData>[K]) => Partial<DealData>[K]
-} = {
-  addonLicenseId: (redact, addonLicenseId) => redact.addonLicenseId(addonLicenseId),
-  amount: (redact, amount) => redact.amount(amount),
-  app: (redact, app) => redact.appName(app),
-  closeDate: (redact, closeDate) => closeDate,
-  country: (redact, country) => country,
-  dealName: (redact, dealName) => redact.dealName(dealName),
-  dealStage: (redact, dealStage) => dealStage,
-  deployment: (redact, deployment) => deployment,
-  licenseTier: (redact, licenseTier) => licenseTier,
-  origin: (redact, origin) => origin,
-  pipeline: (redact, pipeline) => pipeline,
-  relatedProducts: (redact, relatedProducts) => redact.product(relatedProducts),
-  transactionId: (redact, transactionId) => redact.transactionId(transactionId),
-};
-
 export class DealDataLogger {
 
   plainLogger = new FileDealDataLogger(
@@ -71,15 +53,6 @@ export class FileDealDataLogger {
     this.log.close();
   }
 
-  private printDealProperties(data: Partial<DealData>) {
-    for (const [k, v] of Object.entries(data)) {
-      const key = k as keyof DealData;
-      const fn = dealPropertyRedactors[key] as <T>(redact: Redactor, val: T) => T;
-      const val = fn(this.redact, v);
-      this.log.writeLine(`    ${k}: ${val}`);
-    }
-  }
-
   logActions(actions: Action[]) {
     this.log.writeLine('Actions');
     for (const action of actions) {
@@ -96,6 +69,15 @@ export class FileDealDataLogger {
           this.log.writeLine(`  Nothing: ${this.redact.dealId(action.deal.id)}`);
           break;
       }
+    }
+  }
+
+  private printDealProperties(data: Partial<DealData>) {
+    for (const [k, v] of Object.entries(data)) {
+      const key = k as keyof DealData;
+      const fn = dealPropertyRedactors[key] as <T>(redact: Redactor, val: T) => T;
+      const val = fn(this.redact, v);
+      this.log.writeLine(`    ${k}: ${val}`);
     }
   }
 
@@ -257,3 +239,21 @@ class PrivacyRedactor implements Redactor {
   }
 
 }
+
+const dealPropertyRedactors: {
+  [K in keyof DealData]: (redact: Redactor, val: Partial<DealData>[K]) => Partial<DealData>[K]
+} = {
+  addonLicenseId: (redact, addonLicenseId) => redact.addonLicenseId(addonLicenseId),
+  amount: (redact, amount) => redact.amount(amount),
+  app: (redact, app) => redact.appName(app),
+  closeDate: (redact, closeDate) => closeDate,
+  country: (redact, country) => country,
+  dealName: (redact, dealName) => redact.dealName(dealName),
+  dealStage: (redact, dealStage) => dealStage,
+  deployment: (redact, deployment) => deployment,
+  licenseTier: (redact, licenseTier) => licenseTier,
+  origin: (redact, origin) => origin,
+  pipeline: (redact, pipeline) => pipeline,
+  relatedProducts: (redact, relatedProducts) => redact.product(relatedProducts),
+  transactionId: (redact, transactionId) => redact.transactionId(transactionId),
+};

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -3,7 +3,7 @@ import DataDir, { LogWriteStream } from "../../cache/datadir.js";
 import { Table } from "../../log/table.js";
 import { DealData } from "../../model/deal.js";
 import { License } from "../../model/license.js";
-import { Transaction } from "../../model/transaction.js";
+import { uniqueTransactionId, Transaction } from "../../model/transaction.js";
 import { formatMoney } from "../../util/formatters.js";
 import { Action } from "./actions.js";
 import { DealRelevantEvent } from "./events.js";
@@ -148,9 +148,9 @@ export class FileDealDataLogger {
 
   private redactedTransaction(transaction: Transaction | undefined) {
     if (!transaction) return undefined;
-    const txid = this.redact.transactionId(transaction.data.transactionId);
-    const lid = this.redact.addonLicenseId(transaction.data.addonLicenseId);
-    return `${txid}[${lid}]`;
+    const transactionId = this.redact.transactionId(transaction.data.transactionId);
+    const addonLicenseId = this.redact.addonLicenseId(transaction.data.addonLicenseId);
+    return uniqueTransactionId({ data: { transactionId, addonLicenseId } });
   }
 
 }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -2,6 +2,7 @@ import Chance from 'chance';
 import DataDir, { LogWriteStream } from "../../cache/datadir.js";
 import { Table } from "../../log/table.js";
 import { DealData } from "../../model/deal.js";
+import { DealStage } from '../../model/hubspot/interfaces.js';
 import { License } from "../../model/license.js";
 import { uniqueTransactionId, Transaction } from "../../model/transaction.js";
 import { formatMoney } from "../../util/formatters.js";
@@ -70,12 +71,13 @@ export class FileDealDataLogger {
         }
         case 'noop': {
           const dealId = this.redact.dealId(action.deal.id);
-          const { addonLicenseId, transactionId } = action.deal.data;
+          const { amount, addonLicenseId, transactionId, dealStage } = action.deal.data;
           const recordId = (transactionId
             ? this.redactedTransaction({ transactionId, addonLicenseId })
             : this.redact.addonLicenseId(addonLicenseId)
           );
-          this.log.writeLine(`  Nothing: ${dealId} (via ${recordId})`);
+          const stage = DealStage[dealStage];
+          this.log.writeLine(`  Nothing: ${dealId}, via ${recordId}, stage=${stage}, amount=${amount}`);
           break;
         }
       }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -200,38 +200,30 @@ class PrivacyRedactor implements Redactor {
     return rid as T;
   }
 
-  private shortUUID() {
-    return this.chance.string({
-      length: 10,
-      alpha: true,
-      numeric: true,
-      symbols: false,
-      casing: 'lower'
-    });
-  }
-
   public addonLicenseId<T extends R>(val: T): T {
-    return this.redact(val, () => `L[${this.shortUUID()}]`);
+    if (typeof val !== 'string') return val;
+    const L = val.startsWith('L') ? 'L' : '';
+    return this.redact(val, () => `${L}${this.chance.integer({ min: 10000000, max: 99999999 })}`);
   }
 
   public transactionId<T extends R>(val: T): T {
-    return this.redact(val, () => `TX[${this.shortUUID()}]`);
+    return this.redact(val, () => `AT-${this.chance.integer({ min: 10000000, max: 999999999 })}`);
   }
 
   public dealId<T extends R>(val: T): T {
-    return this.redact(val, () => `D[${this.shortUUID()}]`);
+    return this.redact(val, () => `${this.chance.integer({ min: 1000000000, max: 9999999999 })}`);
   }
 
   public appName<T extends R>(val: T): T {
-    return this.redact(val, () => `AppName[${this.chance.word({ capitalize: true, syllables: 2 })}]`);
+    return this.redact(val, () => `AppName_${this.chance.word({ capitalize: true, syllables: 2 })}`);
   }
 
   public dealName<T extends R>(val: T): T {
-    return this.redact(val, () => `DealName[${this.chance.word({ capitalize: true, syllables: 2 })}]`);
+    return this.redact(val, () => `DealName_${this.chance.word({ capitalize: true, syllables: 2 })}`);
   }
 
   public product<T extends R>(val: T): T {
-    return this.redact(val, () => `Product[${this.chance.word({ capitalize: true, syllables: 2 })}]`);
+    return this.redact(val, () => `Product_${this.chance.word({ capitalize: true, syllables: 2 })}`);
   }
 
   public amount<T extends R>(val: T): T {

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -201,12 +201,12 @@ class PrivacyRedactor implements Redactor {
   private redactions = new Map<string | number, string | number>();
   private newIds = new Set<string | number>();
 
-  private redact<T extends R>(id: T, idgen: () => string | number): T {
+  private redact<T extends R>(id: T, idgen: () => string | number, mustBeUnique = true): T {
     if (id === undefined || id === null) return id;
     let rid = this.redactions.get(id);
     if (!rid) {
       do { rid = idgen(); }
-      while (this.newIds.has(rid));
+      while (mustBeUnique && this.newIds.has(rid));
       this.newIds.add(rid);
       this.redactions.set(id, rid)
     };
@@ -240,7 +240,7 @@ class PrivacyRedactor implements Redactor {
   }
 
   public amount<T extends R>(val: T): T {
-    return this.redact(val, () => this.chance.floating({ min: 0, max: 1000 }));
+    return this.redact(val, () => this.chance.floating({ min: 0, max: 1000 }), false);
   }
 
 }

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -71,7 +71,7 @@ export class Transaction {
       vendorAmount: rawTransaction.purchaseDetails.vendorAmount,
     };
 
-    this.id = uniqueTransactionId(this);
+    this.id = uniqueTransactionId(this.data);
     this.tier = this.parseTier();
   }
 
@@ -93,6 +93,6 @@ export class Transaction {
 
 }
 
-export function uniqueTransactionId(transaction: { data: { transactionId: string, addonLicenseId: string } }) {
-  return `${transaction.data.transactionId}[${transaction.data.addonLicenseId}]`
+export function uniqueTransactionId(data: { transactionId: string, addonLicenseId: string }) {
+  return `${data.transactionId}[${data.addonLicenseId}]`
 }

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -71,7 +71,7 @@ export class Transaction {
       vendorAmount: rawTransaction.purchaseDetails.vendorAmount,
     };
 
-    this.id = `${this.data.transactionId}[${this.data.addonLicenseId}]`;
+    this.id = uniqueTransactionId(this);
     this.tier = this.parseTier();
   }
 
@@ -91,4 +91,8 @@ export class Transaction {
     assert.fail(`Unknown transaction tier: ${tier}`);
   }
 
+}
+
+export function uniqueTransactionId(transaction: { data: { transactionId: string, addonLicenseId: string } }) {
+  return `${transaction.data.transactionId}[${transaction.data.addonLicenseId}]`
 }


### PR DESCRIPTION
This finishes most of the subtask in #23 of generating sample data with a redacted copy.

1. The redacted IDs match the format of real IDs, so we'll end up with fake addon-license-ids like L64504661 and 89032315, fake transaction-ids like AT-646765546, and fake deal-ids like 5679651591.

2. The redacted combined-transaction-and-addon-license-ids are now redacted in parts, so they're not "unrelated" to existing IDs. So for example, for AT-646765546 and 89032315, we now print AT-646765546[89032315] whereas before this PR it was a random string that had nothing to do with either of those.

3. We now also print the Transaction/License IDs, deal stage, and amount, for deals that have no action taken on them. This will be useful for quickly seeing (and verifying) why the engine thought no action should be taken.

4. The code is more secure against typos that might accidentally print real data to the redacted output file, by creating the logger file and the redactor at the same time in a new class.