### PR TITLE
Fix run regression

### DIFF
--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -83,19 +83,22 @@ This phase assumes a few things:
 2. Each transaction points to exactly one `addonLicenseId`
 3. Some transactions point to the same `addonLicenseId`
 4. Therefore, we can match up every license with 0-N transactions
-5. The engine calls this a License Context (naming things is hard)
-6. We can always map back each license to its transactions
-7. So we can work with licenses, and be able to traverse their transactions
+5. Each license keeps a reference to all its transactions (as an array)
+6. Each transaction keeps a reference to its license
+7. If a transaction doesn't have an accompanying license, we log and omit it
 
-So, using TypeScript for context, we start with this:
+Using TypeScript to explain this, we basically have:
 
-```typescript
-type LicenseContext = {
-  license: License;
-  transactions: Transaction[];
-};
+```ts
+class License {
+  public transactions!: Transaction[];
+  // ...
+}
 
-let toMatchUp: LicenseContext[];
+class Transaction {
+  public license!: License;
+  // ...
+}
 ```
 
 #### Motivation
@@ -158,12 +161,12 @@ In practice, this means that if 2 licenses are 100 days apart, but matched with 
 
 #### Match results
 
-At the end of this phase, we have a set of matched License Contexts, which the engine calls uncreatively Related License Sets.
+At the end of this phase, we have a set of matched Licenses, which the engine calls uncreatively Related License Sets.
 
-To continue the TypeScript reference from above, at the end of this phase, we have:
+To use TypeScript to demonstrate this, at the end of this phase, we have:
 
 ```typescript
-type RelatedLicenseSet = LicenseContext[];
+type RelatedLicenseSet = License[];
 
 let matchedUp: RelatedLicenseSet[];
 ```

--- a/src/bin/generate-test.ts
+++ b/src/bin/generate-test.ts
@@ -57,11 +57,11 @@ async function getRedactedMatchGroup(ids: [string, string[]][]) {
   const group: RelatedLicenseSet = [];
   for (const [lid, txids] of ids) {
     const license = redactedLicense(db.licenses.find(l => l.id === lid)!);
-    const transactions: Transaction[] = [];
     group.push(license);
     for (const tid of txids) {
       const transaction = redactedTransaction(db.transactions.find(t => t.id === tid)!);
-      transactions.push(transaction);
+      license.transactions.push(transaction);
+      transaction.license = license;
     }
   }
   return group;

--- a/src/bin/generate-test.ts
+++ b/src/bin/generate-test.ts
@@ -3,7 +3,7 @@ import util from 'util';
 import { DealGenerator } from '../lib/engine/deal-generator/generate-deals';
 import { redactedLicense, redactedTransaction } from '../lib/engine/deal-generator/redact';
 import { abbrActionDetails, abbrEventDetails } from '../lib/engine/deal-generator/test/utils';
-import { LicenseContext, RelatedLicenseSet } from '../lib/engine/license-matching/license-grouper';
+import { RelatedLicenseSet } from '../lib/engine/license-matching/license-grouper';
 import { IO } from "../lib/io/io";
 import { Database } from "../lib/model/database";
 import { License } from '../lib/model/license';
@@ -30,7 +30,7 @@ async function main(template: string, testId: string) {
   const db = new Database(new IO());
 
   db.licenses.length = 0;
-  db.licenses.push(...group.map(g => g.license));
+  db.licenses.push(...group);
 
   db.transactions.length = 0;
   db.transactions.push(...group.flatMap(g => g.transactions));
@@ -58,8 +58,7 @@ async function getRedactedMatchGroup(ids: [string, string[]][]) {
   for (const [lid, txids] of ids) {
     const license = redactedLicense(db.licenses.find(l => l.id === lid)!);
     const transactions: Transaction[] = [];
-    const context: LicenseContext = { license, transactions };
-    group.push(context);
+    group.push(license);
     for (const tid of txids) {
       const transaction = redactedTransaction(db.transactions.find(t => t.id === tid)!);
       transactions.push(transaction);

--- a/src/lib/engine/contacts/update-contacts.ts
+++ b/src/lib/engine/contacts/update-contacts.ts
@@ -5,15 +5,15 @@ import { RelatedLicenseSet } from "../license-matching/license-grouper";
 import { flagPartnersViaCoworkers } from "./contact-types";
 
 export function updateContactsBasedOnMatchResults(db: Database, allMatches: RelatedLicenseSet[]) {
-  for (const group of allMatches) {
-    const contacts = new Set(group.map(m => db.contactManager.getByEmail(m.license.data.technicalContact.email)!));
+  for (const license of allMatches) {
+    const contacts = new Set(license.map(license => db.contactManager.getByEmail(license.data.technicalContact.email)!));
 
     flagPartnersViaCoworkers([...contacts]);
 
     for (const contact of contacts) {
       const items = [
-        ...group.map(g => g.license),
-        ...group.flatMap(g => g.transactions)
+        ...license,
+        ...license.flatMap(l => l.transactions)
       ];
 
       for (const tier of items.map(item => item.tier)) {
@@ -28,7 +28,7 @@ export function updateContactsBasedOnMatchResults(db: Database, allMatches: Rela
         }
       }
 
-      const addonKey = group[0].license.data.addonKey;
+      const addonKey = license[0].data.addonKey;
       const product = env.mpac.platforms[addonKey];
       if (!product) {
         throw new KnownError(`Add "${addonKey}" to ADDONKEY_PLATFORMS`);
@@ -37,7 +37,7 @@ export function updateContactsBasedOnMatchResults(db: Database, allMatches: Rela
         contact.data.relatedProducts.add(product);
       }
 
-      const hosting = group[0].license.data.hosting;
+      const hosting = license[0].data.hosting;
       if (!contact.data.deployment) {
         contact.data.deployment = hosting;
       }

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -7,6 +7,11 @@ import { isPresent, sorter } from "../../util/helpers";
 import { abbrEventDetails, DealRelevantEvent, EvalEvent, PurchaseEvent, RefundEvent, RenewalEvent, UpgradeEvent } from "./events";
 import { dealCreationProperties, updateDeal } from "./records";
 
+export type Action = CreateDealAction | UpdateDealAction | IgnoreDealAction;
+export type CreateDealAction = { type: 'create'; properties: DealData };
+export type UpdateDealAction = { type: 'update'; deal: Deal; properties: Partial<DealData> };
+export type IgnoreDealAction = { type: 'noop'; deal: Deal };
+
 export class ActionGenerator {
 
   #handledDeals = new Map<Deal, DealRelevantEvent>();
@@ -168,24 +173,6 @@ export class ActionGenerator {
   }
 
 }
-
-export type CreateDealAction = {
-  type: 'create';
-  properties: DealData;
-};
-
-export type UpdateDealAction = {
-  type: 'update';
-  deal: Deal;
-  properties: Partial<DealData>;
-};
-
-export type NoDealAction = {
-  type: 'noop';
-  deal: Deal;
-};
-
-export type Action = CreateDealAction | UpdateDealAction | NoDealAction;
 
 function makeCreateAction(event: DealRelevantEvent, record: License | Transaction, data: Pick<DealData, 'addonLicenseId' | 'transactionId' | 'dealStage'>): Action {
   return {

--- a/src/lib/engine/deal-generator/events.ts
+++ b/src/lib/engine/deal-generator/events.ts
@@ -2,7 +2,7 @@ import { License } from "../../model/license";
 import { Transaction } from "../../model/transaction";
 import { sorter } from "../../util/helpers";
 import { RelatedLicenseSet } from "../license-matching/license-grouper";
-import { getLicense, isEvalOrOpenSourceLicense, isPaidLicense } from "./records";
+import { isEvalOrOpenSourceLicense, isPaidLicense } from "./records";
 
 export type RefundEvent = { type: 'refund', refundedTxs: Transaction[] };
 export type EvalEvent = { type: 'eval', licenses: License[] };
@@ -22,7 +22,7 @@ export class EventGenerator {
 
   private events: DealRelevantEvent[] = [];
 
-  public interpretAsEvents(records: (License | Transaction)[]) {
+  public interpretAsEvents(records: (License | Transaction)[], getLicense: (id: string) => License) {
     for (const record of records) {
       if (record instanceof License) {
         if (isEvalOrOpenSourceLicense(record)) {
@@ -35,7 +35,7 @@ export class EventGenerator {
       else {
         switch (record.data.saleType) {
           case 'New': {
-            const license = getLicense(record.data.addonLicenseId, records);
+            const license = getLicense(record.data.addonLicenseId);
             this.events.push({ type: 'purchase', licenses: [license], transaction: record });
             break;
           }

--- a/src/lib/engine/deal-generator/events.ts
+++ b/src/lib/engine/deal-generator/events.ts
@@ -22,7 +22,7 @@ export class EventGenerator {
 
   private events: DealRelevantEvent[] = [];
 
-  public interpretAsEvents(records: (License | Transaction)[], getLicense: (id: string) => License) {
+  public interpretAsEvents(records: (License | Transaction)[]) {
     for (const record of records) {
       if (record instanceof License) {
         if (isEvalOrOpenSourceLicense(record)) {
@@ -35,8 +35,7 @@ export class EventGenerator {
       else {
         switch (record.data.saleType) {
           case 'New': {
-            const license = getLicense(record.data.addonLicenseId);
-            this.events.push({ type: 'purchase', licenses: [license], transaction: record });
+            this.events.push({ type: 'purchase', licenses: [record.license], transaction: record });
             break;
           }
           case 'Renewal':

--- a/src/lib/engine/deal-generator/events.ts
+++ b/src/lib/engine/deal-generator/events.ts
@@ -88,14 +88,14 @@ export class EventGenerator {
     }
   }
 
-  public getSortedRecords(groups: RelatedLicenseSet) {
-    return groups.flatMap(group => {
-      const transactions = this.applyRefunds(group.transactions);
+  public getSortedRecords(group: RelatedLicenseSet) {
+    return group.flatMap(license => {
+      const transactions = this.applyRefunds(license.transactions);
       const records: (License | Transaction)[] = [...transactions];
 
       // Include the License unless it's based on a 'New' Transaction
       if (!transactions.some(t => t.data.saleType === 'New')) {
-        records.push(group.license);
+        records.push(license);
       }
 
       return records;

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -112,18 +112,10 @@ export class DealGenerator {
     assert.ok(group.length > 0);
     if (this.ignoring(group)) return { records: [], actions: [], events: [] };
 
-    const getLicense = (addonLicenseId: string) => {
-      const license = (group
-        .sort(sorter(l => l.data.maintenanceStartDate, 'DSC'))
-        .find(l => l.data.addonLicenseId === addonLicenseId));
-      assert.ok(license);
-      return license;
-    }
-
     const eventGenerator = new EventGenerator();
 
     const records = eventGenerator.getSortedRecords(group);
-    const events = eventGenerator.interpretAsEvents(records, getLicense);
+    const events = eventGenerator.interpretAsEvents(records);
     const actions = this.actionGenerator.generateFrom(events);
 
     return { records, events, actions };

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -112,10 +112,19 @@ export class DealGenerator {
     assert.ok(groups.length > 0);
     if (this.ignoring(groups)) return { records: [], actions: [], events: [] };
 
+    const getLicense = (addonLicenseId: string) => {
+      const license = (groups
+        .map(g => g.license)
+        .sort(sorter(l => l.data.maintenanceStartDate, 'DSC'))
+        .find(l => l.data.addonLicenseId === addonLicenseId));
+      assert.ok(license);
+      return license;
+    }
+
     const eventGenerator = new EventGenerator();
 
     const records = eventGenerator.getSortedRecords(groups);
-    const events = eventGenerator.interpretAsEvents(records);
+    const events = eventGenerator.interpretAsEvents(records, getLicense);
     const actions = this.actionGenerator.generateFrom(events);
 
     return { records, events, actions };

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -108,13 +108,12 @@ export class DealGenerator {
     }
   }
 
-  public generateActionsForMatchedGroup(groups: RelatedLicenseSet) {
-    assert.ok(groups.length > 0);
-    if (this.ignoring(groups)) return { records: [], actions: [], events: [] };
+  public generateActionsForMatchedGroup(group: RelatedLicenseSet) {
+    assert.ok(group.length > 0);
+    if (this.ignoring(group)) return { records: [], actions: [], events: [] };
 
     const getLicense = (addonLicenseId: string) => {
-      const license = (groups
-        .map(g => g.license)
+      const license = (group
         .sort(sorter(l => l.data.maintenanceStartDate, 'DSC'))
         .find(l => l.data.addonLicenseId === addonLicenseId));
       assert.ok(license);
@@ -123,15 +122,15 @@ export class DealGenerator {
 
     const eventGenerator = new EventGenerator();
 
-    const records = eventGenerator.getSortedRecords(groups);
+    const records = eventGenerator.getSortedRecords(group);
     const events = eventGenerator.interpretAsEvents(records, getLicense);
     const actions = this.actionGenerator.generateFrom(events);
 
     return { records, events, actions };
   }
 
-  private associateDealContactsAndCompanies(groups: RelatedLicenseSet, deal: Deal) {
-    const records = groups.flatMap(group => [group.license, ...group.transactions]);
+  private associateDealContactsAndCompanies(group: RelatedLicenseSet, deal: Deal) {
+    const records = group.flatMap(license => [license, ...license.transactions]);
     const emails = [...new Set(records.flatMap(getEmails))];
     const contacts = (emails
       .map(email => this.db.contactManager.getByEmail(email))
@@ -154,9 +153,9 @@ export class DealGenerator {
   }
 
   /** Ignore if every license's tech contact domain is partner or mass-provider */
-  private ignoring(groups: RelatedLicenseSet) {
-    const licenses = groups.map(g => g.license);
-    const transactions = groups.flatMap(g => g.transactions);
+  private ignoring(group: RelatedLicenseSet) {
+    const licenses = group;
+    const transactions = group.flatMap(license => license.transactions);
     const records = [...licenses, ...transactions];
     const domains = new Set(records.map(license => license.data.technicalContact.email.toLowerCase().split('@')[1]));
 

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -50,8 +50,8 @@ export class DealDataLogger {
     }
   }
 
-  public logTestID(groups: RelatedLicenseSet) {
-    const ids = groups.map(g => [g.license.id, g.transactions.map(t => t.id)]);
+  public logTestID(group: RelatedLicenseSet) {
+    const ids = group.map(l => [l.id, l.transactions.map(t => t.id)]);
     this.log.writeLine('\n');
     this.log.writeLine(Buffer.from(JSON.stringify(ids), 'utf8').toString('base64'));
   }

--- a/src/lib/engine/deal-generator/records.ts
+++ b/src/lib/engine/deal-generator/records.ts
@@ -1,12 +1,10 @@
-import assert from 'assert';
 import mustache from 'mustache';
 import { Deal, DealData } from '../../model/deal';
 import { DealStage, Pipeline } from '../../model/hubspot/interfaces';
 import { License } from '../../model/license';
 import { Transaction } from '../../model/transaction';
 import env from '../../parameters/env';
-import { isPresent, sorter } from '../../util/helpers';
-import { RelatedLicenseSet } from '../license-matching/license-grouper';
+import { isPresent } from '../../util/helpers';
 
 export function isEvalOrOpenSourceLicense(record: License) {
   return (
@@ -22,16 +20,6 @@ export function isPaidLicense(license: License) {
     license.data.licenseType === 'COMMUNITY' ||
     license.data.licenseType === 'DEMONSTRATION'
   );
-}
-
-export function getLicense(addonLicenseId: string, records: (License | Transaction)[]) {
-  const license = (records
-    .filter((r => r instanceof License) as
-      (r: License | Transaction) => r is License)
-    .sort(sorter(l => l.data.maintenanceStartDate, 'DSC'))
-    .find(l => l.data.addonLicenseId === addonLicenseId));
-  assert.ok(license);
-  return license;
 }
 
 export function dealCreationProperties(record: License | Transaction, data: Pick<DealData, 'addonLicenseId' | 'transactionId' | 'dealStage'>): DealData {

--- a/src/lib/engine/deal-generator/test/utils.ts
+++ b/src/lib/engine/deal-generator/test/utils.ts
@@ -63,9 +63,11 @@ function reassembleMatchGroup(ids: [string, string[]][], records: (License | Tra
   const group: RelatedLicenseSet = [];
   for (const [lid, txids] of ids) {
     const license = licenses.find(l => l.id === lid)!;
+    license.transactions = [];
     for (const tid of txids) {
       const transaction = transactions.find(t => t.id === tid)!;
       license.transactions.push(transaction);
+      transaction.license = license;
     }
     group.push(license);
   }

--- a/src/lib/engine/deal-generator/test/utils.ts
+++ b/src/lib/engine/deal-generator/test/utils.ts
@@ -6,7 +6,7 @@ import { DealStage } from '../../../model/hubspot/interfaces';
 import { License, LicenseData } from "../../../model/license";
 import { ContactInfo } from '../../../model/marketplace/common';
 import { Transaction, TransactionData } from "../../../model/transaction";
-import { LicenseContext, RelatedLicenseSet } from '../../license-matching/license-grouper';
+import { RelatedLicenseSet } from '../../license-matching/license-grouper';
 import { Action } from "../actions";
 import { DealRelevantEvent } from '../events';
 import { DealGenerator } from '../generate-deals';
@@ -28,7 +28,7 @@ export function runDealGenerator(input: TestInput) {
   const io = new IO();
   const db = new Database(io);
   const group = reassembleMatchGroup(input.group, input.records);
-  db.licenses = group.map(g => g.license);
+  db.licenses = group;
   db.transactions = group.flatMap(g => g.transactions);
 
   for (const [i, dealData] of (input.deals ?? []).entries()) {
@@ -63,12 +63,11 @@ function reassembleMatchGroup(ids: [string, string[]][], records: (License | Tra
   const group: RelatedLicenseSet = [];
   for (const [lid, txids] of ids) {
     const license = licenses.find(l => l.id === lid)!;
-    const context: LicenseContext = { license, transactions: [] };
     for (const tid of txids) {
       const transaction = transactions.find(t => t.id === tid)!;
-      context.transactions.push(transaction);
+      license.transactions.push(transaction);
     }
-    group.push(context);
+    group.push(license);
   }
   return group;
 }

--- a/src/lib/engine/license-matching/license-grouper.ts
+++ b/src/lib/engine/license-matching/license-grouper.ts
@@ -10,15 +10,13 @@ import { Transaction } from '../../model/transaction';
 import { sorter } from '../../util/helpers';
 import { LicenseMatcher } from './license-matcher';
 
-export type LicenseContext = License;
-
 /** Related via the matching engine. */
-export type RelatedLicenseSet = LicenseContext[];
+export type RelatedLicenseSet = License[];
 
 
 export function matchIntoLikelyGroups(db: Database): RelatedLicenseSet[] {
   log.info('Scoring Engine', 'Storing licenses/transactions by id');
-  const itemsByAddonLicenseId: Map<AddonLicenseId, LicenseContext> = buildMappingStructure(db);
+  const itemsByAddonLicenseId: Map<AddonLicenseId, License> = buildMappingStructure(db);
 
   log.info('Scoring Engine', 'Grouping licenses/transactions by hosting and addonKey');
   const productGroupings: Iterable<{ addonKey: string; hosting: string; group: License[] }> = groupMappingByProduct(itemsByAddonLicenseId);
@@ -150,7 +148,7 @@ function buildMappingStructure(db: Database) {
   return mapping;
 }
 
-function groupMappingByProduct(mapping: Map<AddonLicenseId, LicenseContext>) {
+function groupMappingByProduct(mapping: Map<AddonLicenseId, License>) {
   const productMapping = new Map<string, {
     addonKey: string,
     hosting: string,

--- a/src/lib/model/license.ts
+++ b/src/lib/model/license.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import { AddonLicenseId, ContactInfo, getContactInfo, getPartnerInfo, maybeGetContactInfo, PartnerInfo } from "./marketplace/common";
 import { RawLicense } from "./marketplace/raw";
+import { Transaction } from './transaction';
 
 type AttributionData = {
   channel: string;
@@ -61,6 +62,8 @@ export class License {
   public id: string;
   public tier: number;
   public active: boolean;
+
+  public transactions: Transaction[] = [];
 
   static fromRaw(rawLicense: RawLicense) {
     let newEvalData: NewEvalData | null = null;

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import { License } from "./license";
 import { AddonLicenseId, ContactInfo, getContactInfo, getPartnerInfo, maybeGetContactInfo, PartnerInfo } from "./marketplace/common";
 import { RawTransaction } from "./marketplace/raw";
 
@@ -38,6 +39,8 @@ export class Transaction {
   /** Unique ID for this Transaction. */
   public id: string;
   public tier: number;
+
+  public license!: License;
 
   static fromRaw(rawTransaction: RawTransaction) {
     return new Transaction({


### PR DESCRIPTION
The recent test suite PR had one regression, due to passing a list of MPAC records *after* combining evals. This meant it couldn't find a license for a given `addonLicenseId`.

But the good news is that this made me realize that *there's absolutely no need for a LicenseContext type.* We can just use a License, which can have an array of its Transactions, and each Transaction can store a ref to its License.

This will also help in the Partner Transactions task, which has to traverse licenses and transactions in order to find out their contacts and contact types. From now on, we should always be linking refs as early on as we can in the engine.