### PR TITLE
Fix balance summary reporting

### DIFF
--- a/src/bin/cli-args.ts
+++ b/src/bin/cli-args.ts
@@ -1,6 +1,7 @@
 import { Remote } from "../lib/io/interfaces";
 import { CachedMemoryRemote, IO, LiveRemote } from "../lib/io/io";
 import { cli } from "../lib/parameters/cli-args";
+import { serviceCredsFromENV } from "../lib/parameters/env-config";
 
 export function ioFromCliArgs() {
   const io = new IO();
@@ -23,7 +24,7 @@ export function ioFromCliArgs() {
   function remoteFor(opt: 'local' | 'remote'): Remote {
     switch (opt) {
       case 'local': return new CachedMemoryRemote();
-      case 'remote': return new LiveRemote();
+      case 'remote': return new LiveRemote(serviceCredsFromENV());
     }
   }
 }

--- a/src/bin/download.ts
+++ b/src/bin/download.ts
@@ -2,14 +2,14 @@ import 'source-map-support/register';
 import { IO, LiveRemote, MemoryRemote } from "../lib/io/io";
 import log from "../lib/log/logger";
 import { Database } from "../lib/model/database";
-import { envConfig } from '../lib/parameters/env-config';
+import { envConfig, serviceCredsFromENV } from '../lib/parameters/env-config';
 
 main();
 async function main() {
 
   log.level = log.Levels.Verbose;
   const io = new IO();
-  io.in = new LiveRemote();
+  io.in = new LiveRemote(serviceCredsFromENV());
   io.out = new MemoryRemote();
   const db = new Database(io, envConfig);
   await db.downloadAllData();

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -31,7 +31,7 @@ async function main() {
     },
 
     async failed(errors) {
-      await slack.postToSlack(`Failed ${env.engine.retryTimes} times. Below are the specific errors, in order. Trying again in ${env.engine.runInterval}.`);
+      await slack.postToSlack(`Failed ${env.loop.retryTimes} times. Below are the specific errors, in order. Trying again in ${env.loop.runInterval}.`);
       for (const error of errors) {
         if (error instanceof KnownError) {
           await slack.postErrorToSlack(error.message);

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -5,7 +5,7 @@ import Slack from "../lib/io/slack";
 import log from '../lib/log/logger';
 import { Database } from "../lib/model/database";
 import { cli } from "../lib/parameters/cli-args";
-import env, { envConfig } from "../lib/parameters/env-config";
+import env, { envConfig, slackConfigFromENV } from "../lib/parameters/env-config";
 import { AttachableError, KnownError } from "../lib/util/errors";
 import run from "../lib/util/runner";
 import { ioFromCliArgs } from './cli-args';
@@ -19,9 +19,14 @@ async function main() {
   const io = ioFromCliArgs();
   cli.failIfExtraOpts();
 
-  const slack = new Slack();
+  let slack: Slack | undefined;
+  const slackConfig = slackConfigFromENV();
+  if (slackConfig.apiToken) {
+    const { apiToken, errorChannelId } = slackConfig;
+    slack = new Slack(apiToken, errorChannelId);
+  }
 
-  await slack.postToSlack(`Starting Marketing Engine`);
+  await slack?.postToSlack(`Starting Marketing Engine`);
 
   await run({
 
@@ -31,20 +36,20 @@ async function main() {
     },
 
     async failed(errors) {
-      await slack.postToSlack(`Failed ${env.loop.retryTimes} times. Below are the specific errors, in order. Trying again in ${env.loop.runInterval}.`);
+      await slack?.postToSlack(`Failed ${env.loop.retryTimes} times. Below are the specific errors, in order. Trying again in ${env.loop.runInterval}.`);
       for (const error of errors) {
         if (error instanceof KnownError) {
-          await slack.postErrorToSlack(error.message);
+          await slack?.postErrorToSlack(error.message);
         }
         else if (error instanceof AttachableError) {
-          await slack.postErrorToSlack(`\`\`\`\n${error.stack}\n\`\`\``);
-          await slack.postAttachmentToSlack({
+          await slack?.postErrorToSlack(`\`\`\`\n${error.stack}\n\`\`\``);
+          await slack?.postAttachmentToSlack({
             title: 'Error attachment for ^',
             content: error.attachment,
           });
         }
         else {
-          await slack.postErrorToSlack(`\`\`\`\n${error.stack}\n\`\`\``);
+          await slack?.postErrorToSlack(`\`\`\`\n${error.stack}\n\`\`\``);
         }
       }
     },

--- a/src/lib/engine/contacts/generate-contacts.ts
+++ b/src/lib/engine/contacts/generate-contacts.ts
@@ -186,5 +186,5 @@ export function mergeContactInfo(contact: ContactData, contacts: GeneratedContac
 }
 
 function notIgnored(addonKey: string) {
-  return !env.engine.ignoredApps.has(addonKey);
+  return !env.engine.archivedApps.has(addonKey);
 }

--- a/src/lib/engine/contacts/generate-contacts.ts
+++ b/src/lib/engine/contacts/generate-contacts.ts
@@ -20,7 +20,6 @@ export class ContactGenerator {
     this.mergeGeneratedContacts();
     this.associateContacts();
     this.sortContactRecords();
-    this.flagPartnerTransactedContacts();
   }
 
   private generateContacts() {
@@ -57,24 +56,6 @@ export class ContactGenerator {
   private sortContactRecords() {
     for (const contact of this.db.contactManager.getAll()) {
       contact.records.sort(sorter(r => r.data.maintenanceStartDate, 'DSC'));
-    }
-  }
-
-  private flagPartnerTransactedContacts() {
-    /**
-     * If the contact's most recent record has a partner,
-     * set that partner's domain as last associated partner.
-     * Otherwise set it to blank, ignoring previous records.
-     */
-
-    for (const contact of this.db.contactManager.getAll()) {
-      contact.data.lastAssociatedPartner = null;
-
-      const lastRecord = contact.records[0];
-      if (lastRecord) {
-        const partnerDomain = lastRecord.getPartnerDomain(this.db.partnerDomains);
-        contact.data.lastAssociatedPartner = partnerDomain ?? null;
-      }
     }
   }
 

--- a/src/lib/engine/contacts/update-contacts.ts
+++ b/src/lib/engine/contacts/update-contacts.ts
@@ -33,7 +33,7 @@ export function updateContactsBasedOnMatchResults(db: Database, allMatches: Rela
       if (!product) {
         throw new KnownError(`Add "${addonKey}" to ADDONKEY_PLATFORMS`);
       }
-      if (!env.engine.ignoredApps.has(addonKey)) {
+      if (!env.engine.archivedApps.has(addonKey)) {
         contact.data.relatedProducts.add(product);
       }
 

--- a/src/lib/engine/contacts/update-contacts.ts
+++ b/src/lib/engine/contacts/update-contacts.ts
@@ -2,7 +2,6 @@ import { domainFor } from "../../model/contact";
 import { Database } from "../../model/database";
 import { License } from "../../model/license";
 import { Transaction } from "../../model/transaction";
-import env from "../../parameters/env-config";
 import { KnownError } from "../../util/errors";
 import { isPresent } from "../../util/helpers";
 import { RelatedLicenseSet } from "../license-matching/license-grouper";
@@ -33,11 +32,11 @@ export function updateContactsBasedOnMatchResults(db: Database, allMatches: Rela
       }
 
       const addonKey = license[0].data.addonKey;
-      const product = env.mpac.platforms[addonKey];
+      const product = db.appToPlatform[addonKey];
       if (!product) {
         throw new KnownError(`Add "${addonKey}" to ADDONKEY_PLATFORMS`);
       }
-      if (!env.engine.archivedApps.has(addonKey)) {
+      if (!db.archivedApps.has(addonKey)) {
         contact.data.relatedProducts.add(product);
       }
 

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -1,5 +1,6 @@
 import mustache from 'mustache';
 import log from "../../log/logger";
+import { domainFor } from '../../model/contact';
 import { Deal, DealData, DealManager } from "../../model/deal";
 import { DealStage, Pipeline } from "../../model/hubspot/interfaces";
 import { License } from "../../model/license";
@@ -23,21 +24,21 @@ export class ActionGenerator {
     private ignore: (reason: string, amount: number) => void,
   ) { }
 
-  public generateFrom(events: DealRelevantEvent[]) {
-    return events.flatMap(event => this.actionsFor(event));
+  public generateFrom(records: (License | Transaction)[], events: DealRelevantEvent[]) {
+    return events.flatMap(event => this.actionsFor(records, event));
   }
 
-  private actionsFor(event: DealRelevantEvent): Action[] {
+  private actionsFor(records: (License | Transaction)[], event: DealRelevantEvent): Action[] {
     switch (event.type) {
-      case 'eval': return [this.actionForEval(event)];
-      case 'purchase': return [this.actionForPurchase(event)];
-      case 'renewal': return [this.actionForRenewal(event)];
-      case 'upgrade': return [this.actionForRenewal(event)];
-      case 'refund': return this.actionsForRefund(event);
+      case 'eval': return [this.actionForEval(records, event)];
+      case 'purchase': return [this.actionForPurchase(records, event)];
+      case 'renewal': return [this.actionForRenewal(records, event)];
+      case 'upgrade': return [this.actionForRenewal(records, event)];
+      case 'refund': return this.actionsForRefund(records, event);
     }
   }
 
-  private actionForEval(event: EvalEvent): Action {
+  private actionForEval(records: (License | Transaction)[], event: EvalEvent): Action {
     const deal = this.singleDeal(this.dealManager.getDealsForRecords(event.licenses));
     if (deal) this.recordSeen(deal, event);
 
@@ -46,7 +47,7 @@ export class ActionGenerator {
 
     const latestLicense = event.licenses[event.licenses.length - 1];
     if (!deal) {
-      return makeCreateAction(latestLicense, {
+      return makeCreateAction(records, latestLicense, {
         dealStage: event.licenses.some(l => l.active)
           ? DealStage.EVAL
           : DealStage.CLOSED_LOST,
@@ -58,14 +59,14 @@ export class ActionGenerator {
       const dealStage = (event.licenses.some(l => l.active)
         ? DealStage.EVAL
         : DealStage.CLOSED_LOST);
-      return makeUpdateAction(deal, latestLicense, dealStage);
+      return makeUpdateAction(records, deal, latestLicense, dealStage);
     }
     else {
-      return makeUpdateAction(deal, latestLicense);
+      return makeUpdateAction(records, deal, latestLicense);
     }
   }
 
-  private actionForPurchase(event: PurchaseEvent): Action {
+  private actionForPurchase(records: (License | Transaction)[], event: PurchaseEvent): Action {
     const recordsToSearch = [event.transaction, ...event.licenses].filter(isPresent);
     const deal = this.singleDeal(this.dealManager.getDealsForRecords(recordsToSearch));
     if (deal) this.recordSeen(deal, event);
@@ -76,10 +77,10 @@ export class ActionGenerator {
     if (deal) {
       const record = event.transaction || getLatestLicense(event);
       const dealStage = deal.isEval() ? DealStage.CLOSED_WON : deal.data.dealStage;
-      return makeUpdateAction(deal, record, dealStage);
+      return makeUpdateAction(records, deal, record, dealStage);
     }
     else if (event.transaction) {
-      return makeCreateAction(event.transaction, {
+      return makeCreateAction(records, event.transaction, {
         dealStage: DealStage.CLOSED_WON,
         addonLicenseId: event.transaction.data.addonLicenseId,
         transactionId: event.transaction.data.transactionId,
@@ -87,7 +88,7 @@ export class ActionGenerator {
     }
     else {
       const license = getLatestLicense(event);
-      return makeCreateAction(license, {
+      return makeCreateAction(records, license, {
         dealStage: DealStage.CLOSED_WON,
         addonLicenseId: license.data.addonLicenseId,
         transactionId: null,
@@ -95,7 +96,7 @@ export class ActionGenerator {
     }
   }
 
-  private actionForRenewal(event: RenewalEvent | UpgradeEvent): Action {
+  private actionForRenewal(records: (License | Transaction)[], event: RenewalEvent | UpgradeEvent): Action {
     const deal = this.singleDeal(this.dealManager.getDealsForRecords([event.transaction]));
     if (deal) this.recordSeen(deal, event);
 
@@ -103,23 +104,23 @@ export class ActionGenerator {
     if (metaAction) return metaAction;
 
     if (deal) {
-      return makeUpdateAction(deal, event.transaction);
+      return makeUpdateAction(records, deal, event.transaction);
     }
-    return makeCreateAction(event.transaction, {
+    return makeCreateAction(records, event.transaction, {
       dealStage: DealStage.CLOSED_WON,
       addonLicenseId: event.transaction.data.addonLicenseId,
       transactionId: event.transaction.data.transactionId,
     });
   }
 
-  private actionsForRefund(event: RefundEvent): Action[] {
+  private actionsForRefund(records: (License | Transaction)[], event: RefundEvent): Action[] {
     const deals = this.dealManager.getDealsForRecords(event.refundedTxs);
     for (const deal of deals) {
       this.recordSeen(deal, event);
     }
 
     return ([...deals]
-      .map(deal => makeUpdateAction(deal, null, DealStage.CLOSED_LOST, { amount: 0 }))
+      .map(deal => makeUpdateAction(records, deal, null, DealStage.CLOSED_LOST, { amount: 0 }))
       .filter(isPresent)
     );
   }
@@ -205,14 +206,14 @@ export class ActionGenerator {
 
 }
 
-function makeCreateAction(record: License | Transaction, data: Pick<DealData, 'addonLicenseId' | 'transactionId' | 'dealStage'>): Action {
+function makeCreateAction(records: (License | Transaction)[], record: License | Transaction, data: Pick<DealData, 'addonLicenseId' | 'transactionId' | 'dealStage'>): Action {
   return {
     type: 'create',
-    properties: dealCreationProperties(record, data),
+    properties: dealCreationProperties(records, record, data),
   };
 }
 
-function makeUpdateAction(deal: Deal, record: License | Transaction | null, dealstage?: DealStage, certainData?: Partial<DealData>): Action {
+function makeUpdateAction(records: (License | Transaction)[], deal: Deal, record: License | Transaction | null, dealstage?: DealStage, certainData?: Partial<DealData>): Action {
   if (dealstage !== undefined) deal.data.dealStage = dealstage;
   if (record) {
     const dataToEnsure = {
@@ -224,7 +225,7 @@ function makeUpdateAction(deal: Deal, record: License | Transaction | null, deal
       dataToEnsure.transactionId = record.data.transactionId;
       dataToEnsure.addonLicenseId = record.data.addonLicenseId;
     }
-    Object.assign(deal.data, dealCreationProperties(record, dataToEnsure));
+    Object.assign(deal.data, dealCreationProperties(records, record, dataToEnsure));
     deal.data.licenseTier = Math.max(deal.data.licenseTier ?? -1, record.tier);
   }
 
@@ -247,7 +248,22 @@ function getLatestLicense(event: PurchaseEvent): License {
   return [...event.licenses].sort(sorter(item => item.data.maintenanceStartDate, 'DSC'))[0];
 }
 
-function dealCreationProperties(record: License | Transaction, data: Pick<DealData, 'addonLicenseId' | 'transactionId' | 'dealStage'>): DealData {
+function dealCreationProperties(records: (License | Transaction)[], record: License | Transaction, data: Pick<DealData, 'addonLicenseId' | 'transactionId' | 'dealStage'>): DealData {
+  /**
+   * If any record in any of the deal's groups have partner contacts
+   * then use the most recent record's partner contact's domain.
+   * Otherwise set this to null.
+   */
+  const lastPartnerEmail = ([...records]
+    .reverse()
+    .find(r => r.partnerContact)
+    ?.partnerContact
+    ?.data.email);
+
+  const associatedPartner = (lastPartnerEmail
+    ? domainFor(lastPartnerEmail)
+    : null);
+
   return {
     ...data,
     closeDate: (record instanceof Transaction
@@ -261,7 +277,7 @@ function dealCreationProperties(record: License | Transaction, data: Pick<DealDa
     relatedProducts: env.hubspot.deals.dealRelatedProducts ?? null,
     dealName: mustache.render(env.hubspot.deals.dealDealName, record.data),
     pipeline: Pipeline.MPAC,
-    associatedPartner: null,
+    associatedPartner,
     amount: (data.dealStage === DealStage.EVAL
       ? null
       : record instanceof License

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -1,6 +1,5 @@
 import mustache from 'mustache';
 import log from "../../log/logger";
-import { domainFor } from '../../model/contact';
 import { Deal, DealData, DealManager } from "../../model/deal";
 import { DealStage, Pipeline } from "../../model/hubspot/interfaces";
 import { License } from "../../model/license";
@@ -254,15 +253,11 @@ function dealCreationProperties(records: (License | Transaction)[], record: Lice
    * then use the most recent record's partner contact's domain.
    * Otherwise set this to null.
    */
-  const lastPartnerEmail = ([...records]
+  const associatedPartner = ([...records]
     .reverse()
-    .find(r => r.partnerContact)
-    ?.partnerContact
-    ?.data.email);
-
-  const associatedPartner = (lastPartnerEmail
-    ? domainFor(lastPartnerEmail)
-    : null);
+    .map(record => record.partnerDomain)
+    .find(domain => domain)
+    ?? null);
 
   return {
     ...data,

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -190,7 +190,13 @@ export class ActionGenerator {
     switch (event.meta) {
       case 'archived-app':
       case 'mass-provider-only':
-        this.ignore(event.meta, amount);
+        const reason = (event.meta === 'archived-app'
+          ? 'Archived-app transaction'
+          : 'Mass-provider transaction'
+        );
+        if (!deal) {
+          this.ignore(reason, amount);
+        }
         return { type: 'noop', deal, reason: event.meta };
       default:
         return null;

--- a/src/lib/engine/deal-generator/events.ts
+++ b/src/lib/engine/deal-generator/events.ts
@@ -5,7 +5,7 @@ import env from "../../parameters/env-config";
 import { sorter } from "../../util/helpers";
 import { RelatedLicenseSet } from "../license-matching/license-grouper";
 
-type EventMeta = 'partner-only' | 'mass-provider-only' | 'partner-and-mass-provider-only' | 'archived-app' | null;
+export type EventMeta = 'partner-only' | 'mass-provider-only' | 'partner-and-mass-provider-only' | 'archived-app' | null;
 
 export type RefundEvent = { type: 'refund', refundedTxs: Transaction[] };
 export type EvalEvent = { type: 'eval', meta: EventMeta, licenses: License[] };

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -46,11 +46,11 @@ export class DealGenerator {
           ? this.db.dealManager.create(action.properties)
           : action.deal);
 
-        deal.records = records;
-
-        this.associateDealContactsAndCompanies(relatedLicenseIds, deal);
-
-        this.flagPartnerTransacted(deal);
+        if (deal) {
+          deal.records = records;
+          this.associateDealContactsAndCompanies(relatedLicenseIds, deal);
+          this.flagPartnerTransacted(deal);
+        }
       }
     }
 

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -151,14 +151,14 @@ export class DealGenerator {
   private ignoring(group: RelatedLicenseSet) {
     const licenses = group;
     const transactions = group.flatMap(license => license.transactions);
-    const records = [...licenses, ...transactions];
-    const domains = new Set(records.map(license => license.data.technicalContact.email.toLowerCase().split('@')[1]));
 
-    if (records.every(r => hasIgnoredApp(r.data))) {
-      this.ignoreLicenses("Archived app", records[0].data.addonKey, licenses, transactions);
+    if (env.engine.ignoredApps.has(licenses[0].data.addonKey)) {
+      this.ignoreLicenses("Archived app", licenses[0].data.addonKey, licenses, transactions);
       return true;
     }
 
+    const records = [...licenses, ...transactions];
+    const domains = new Set(records.map(license => license.data.technicalContact.email.toLowerCase().split('@')[1]));
     const partnerDomains = [...domains].filter(domain => this.db.partnerDomains.has(domain));
     const providerDomains = [...domains].filter(domain => this.db.providerDomains.has(domain));
 
@@ -220,8 +220,4 @@ export class DealGenerator {
     deal.data.associatedPartner = lastPartner?.getPartnerDomain(this.db.partnerDomains) ?? null;
   }
 
-}
-
-function hasIgnoredApp(record: { addonKey: string }) {
-  return env.engine.ignoredApps.has(record.addonKey);
 }

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -45,9 +45,7 @@ export class DealGenerator {
           : action.deal);
 
         if (deal) {
-          deal.records = records;
           this.associateDealContactsAndCompanies(relatedLicenseIds, deal);
-          this.flagPartnerTransacted(deal);
         }
       }
     }
@@ -83,7 +81,7 @@ export class DealGenerator {
 
     const records = eventGenerator.getSortedRecords(group);
     const events = eventGenerator.interpretAsEvents(records);
-    const actions = this.actionGenerator.generateFrom(events);
+    const actions = this.actionGenerator.generateFrom(records, events);
 
     return { records, events, actions };
   }
@@ -109,26 +107,6 @@ export class DealGenerator {
     for (const company of companies) {
       deal.companies.add(company);
     }
-  }
-
-  public flagPartnerTransacted(deal: Deal) {
-    if (deal.records.length === 0) {
-      log.error('Deal Actions', "Deal has no associated MPAC records:", deal.id);
-      return;
-    }
-
-    /**
-     * If any record in any of the deal's groups have partner contacts
-     * then use the most recent record's partner contact's domain.
-     * Otherwise set this to null.
-     */
-    const lastPartner = (deal
-      .records
-      .flatMap(r => r.allContacts)
-      .reverse()
-      .find(c => c.isPartner));
-
-    deal.data.associatedPartner = lastPartner?.getPartnerDomain(this.db.partnerDomains) ?? null;
   }
 
   private ignore(reason: string, amount: number) {

--- a/src/lib/engine/deal-generator/generate-deals.ts
+++ b/src/lib/engine/deal-generator/generate-deals.ts
@@ -152,7 +152,7 @@ export class DealGenerator {
     const licenses = group;
     const transactions = group.flatMap(license => license.transactions);
 
-    if (env.engine.ignoredApps.has(licenses[0].data.addonKey)) {
+    if (env.engine.archivedApps.has(licenses[0].data.addonKey)) {
       this.ignoreLicenses("Archived app", licenses[0].data.addonKey, licenses, transactions);
       return true;
     }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -84,11 +84,13 @@ export class DealDataLogger {
           type: e.type,
           lics: e.licenses.map(l => l.id),
           txs: [],
+          meta: e.meta,
         };
         case 'purchase': return {
           type: e.type,
           lics: e.licenses.map(l => l.id),
           txs: [e.transaction?.id],
+          meta: e.meta,
         };
         case 'refund': return {
           type: e.type,
@@ -99,11 +101,13 @@ export class DealDataLogger {
           type: e.type,
           lics: [],
           txs: [e.transaction.id],
+          meta: e.meta,
         };
         case 'upgrade': return {
           type: e.type,
           lics: [],
           txs: [e.transaction.id],
+          meta: e.meta,
         };
       }
     });
@@ -116,6 +120,7 @@ export class DealDataLogger {
         [{ title: 'Type' }, row => row.type],
         [{ title: 'Licenses' }, row => row.lics?.join(', ') ?? ''],
         [{ title: 'Transactions' }, row => row.txs?.join(', ') ?? ''],
+        [{ title: 'Partner-only' }, row => row.meta ?? ''],
       ],
     });
   }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -124,7 +124,7 @@ export class DealDataLogger {
         [{ title: 'Type' }, row => row.type],
         [{ title: 'Licenses' }, row => row.lics?.join(', ') ?? ''],
         [{ title: 'Transactions' }, row => row.txs?.join(', ') ?? ''],
-        [{ title: 'Partner-only' }, row => row.meta ?? ''],
+        [{ title: 'Metadata' }, row => row.meta ?? ''],
       ],
     });
   }

--- a/src/lib/engine/deal-generator/logger.ts
+++ b/src/lib/engine/deal-generator/logger.ts
@@ -3,7 +3,7 @@ import { Table } from "../../log/table.js";
 import { DealData } from "../../model/deal.js";
 import { DealStage } from '../../model/hubspot/interfaces.js';
 import { License } from "../../model/license.js";
-import { Transaction, uniqueTransactionId } from "../../model/transaction.js";
+import { Transaction } from "../../model/transaction.js";
 import { formatMoney } from "../../util/formatters.js";
 import { RelatedLicenseSet } from "../license-matching/license-grouper.js";
 import { Action } from "./actions.js";
@@ -33,11 +33,15 @@ export class DealDataLogger {
           break;
         }
         case 'noop': {
-          const dealId = action.deal.id;
-          const { amount, dealStage } = action.deal.data;
-          const recordId = action.deal.mpacId();
-          const stage = DealStage[dealStage];
-          this.log.writeLine(`  Nothing: ${dealId}, via ${recordId}, stage=${stage}, amount=${amount}`);
+          let details = `  Nothing: [${action.reason}]`;
+          if (action.deal) {
+            const dealId = action.deal.id;
+            const { amount, dealStage } = action.deal.data;
+            const recordId = action.deal.mpacId();
+            const stage = DealStage[dealStage];
+            details += ` deal=${dealId}, record=${recordId}, stage=${stage}, amount=${amount}`;
+          }
+          this.log.writeLine(details);
           break;
         }
       }

--- a/src/lib/engine/deal-generator/test/test-cases/basics.test.ts
+++ b/src/lib/engine/deal-generator/test/test-cases/basics.test.ts
@@ -36,7 +36,7 @@ it(`Does not create deal from purchase when one already exists`, () => {
   ]);
   expect(actions).toEqual([
     {
-      Nothing: ['2454822', 'CLOSED_WON', 0]
+      Nothing: ['properties-up-to-date', ['2454822', 'CLOSED_WON', 0]]
     }
   ]);
 });
@@ -103,8 +103,8 @@ it(`Does nothing when upgrades and renewals already have deals`, () => {
     ['renewal', 'AT-131949332[2479625]']
   ]);
   expect(actions).toEqual([
-    { Nothing: ["2479625", "CLOSED_WON", 0,] },
-    { Nothing: ["AT-97165138[2479625]", "CLOSED_WON", 411,] },
-    { Nothing: ["AT-131949332[2479625]", "CLOSED_WON", 274,] },
+    { Nothing: ['properties-up-to-date', ["2479625", "CLOSED_WON", 0,]] },
+    { Nothing: ['properties-up-to-date', ["AT-97165138[2479625]", "CLOSED_WON", 411,]] },
+    { Nothing: ['properties-up-to-date', ["AT-131949332[2479625]", "CLOSED_WON", 274,]] },
   ]);
 });

--- a/src/lib/engine/deal-generator/test/test-cases/partner-transacted.test.ts
+++ b/src/lib/engine/deal-generator/test/test-cases/partner-transacted.test.ts
@@ -1,7 +1,7 @@
 import { runDealGenerator, runDealGeneratorTwice, testLicense } from "../utils";
 
 
-it(`Sets partner domain on deal if record is partern-transacted`, () => {
+it(`Sets partner domain on deal if record is partner-transacted`, () => {
   const license1 = testLicense("1111111", "2021-12-26", "EVAL", "inactive");
   const license2 = testLicense("2222222", "2021-12-27", "COMMERCIAL", "active");
   const partnerDomain = license2.data.technicalContact.email.split('@')[1];
@@ -19,7 +19,7 @@ it(`Sets partner domain on deal if record is partern-transacted`, () => {
   expect(deal.data.associatedPartner).toEqual(partnerDomain);
 });
 
-it(`Sets partner domain on deal if record is partern-transacted even if newer one is not`, () => {
+it(`Sets partner domain on deal if record is partner-transacted even if newer one is not`, () => {
   const license1 = testLicense("1111111", "2021-12-26", "EVAL", "inactive");
   const license2 = testLicense("2222222", "2021-12-27", "COMMERCIAL", "active");
   const partnerDomain = license1.data.technicalContact.email.split('@')[1];

--- a/src/lib/engine/deal-generator/test/utils.ts
+++ b/src/lib/engine/deal-generator/test/utils.ts
@@ -48,11 +48,6 @@ export function runDealGenerator(input: TestInput) {
   const dealGenerator = new DealGenerator(db);
   const { records, events, actions } = dealGenerator.generateActionsForMatchedGroup(group);
 
-  for (const deal of db.dealManager.getAll()) {
-    deal.records = records;
-    dealGenerator.flagPartnerTransacted(deal);
-  }
-
   const createdDeals: DealData[] = [];
   for (const [i, action] of actions.entries()) {
     if (action.type === 'create') {

--- a/src/lib/engine/deal-generator/test/utils.ts
+++ b/src/lib/engine/deal-generator/test/utils.ts
@@ -193,11 +193,11 @@ export function abbrActionDetails(action: Action) {
         action.properties,]
     };
     case 'noop': return {
-      "Nothing": [
+      "Nothing": [action.reason, action.deal && [
         action.deal.mpacId(),
         DealStage[action.deal.data.dealStage],
         action.deal.data.amount,
-      ]
+      ]]
     };
   }
 }

--- a/src/lib/engine/summary.ts
+++ b/src/lib/engine/summary.ts
@@ -24,6 +24,9 @@ export function printSummary(db: Database) {
       .reduce((a, b) => a + b));
 
     log.warn('Deal Generator', 'Total of duplicates:', formatMoney(dupTotal));
+    log.warn('Deal Generator', 'Total duplicates:', db.dealManager.duplicatesToDelete.size);
+
+    db.tallier.less('Over-accounted: Duplicate deals', -dupTotal);
   }
 
   const deals = db.dealManager.getArray();

--- a/src/lib/io/io.ts
+++ b/src/lib/io/io.ts
@@ -1,4 +1,5 @@
-import { Remote } from "./interfaces";
+import { HubspotCreds, MpacCreds } from "../parameters/interfaces";
+import { HubspotService, MarketplaceService, Remote } from "./interfaces";
 import { LiveTldListerService } from "./live/domains";
 import { LiveEmailProviderListerService } from "./live/email-providers";
 import LiveHubspotService from "./live/hubspot";
@@ -37,8 +38,16 @@ export class MemoryRemote implements Remote {
 }
 
 export class LiveRemote implements Remote {
-  hubspot = new LiveHubspotService();
-  marketplace = new LiveMarketplaceService();
+  hubspot: HubspotService;
+  marketplace: MarketplaceService;
   emailProviderLister = new LiveEmailProviderListerService();
   tldLister = new LiveTldListerService();
+
+  constructor(config: {
+    hubspotCreds: HubspotCreds,
+    mpacCreds: MpacCreds,
+  }) {
+    this.hubspot = new LiveHubspotService(config.hubspotCreds);
+    this.marketplace = new LiveMarketplaceService(config.mpacCreds);
+  }
 }

--- a/src/lib/io/live/hubspot.ts
+++ b/src/lib/io/live/hubspot.ts
@@ -2,7 +2,7 @@ import * as hubspot from '@hubspot/api-client';
 import assert from 'assert';
 import log from '../../log/logger';
 import { Association, EntityKind, ExistingEntity, FullEntity, NewEntity, RelativeAssociation } from '../../model/hubspot/interfaces';
-import env from '../../parameters/env-config';
+import { HubspotCreds } from '../../parameters/interfaces';
 import { KnownError } from '../../util/errors';
 import { batchesOf } from '../../util/helpers';
 import cache from '../cache';
@@ -10,9 +10,11 @@ import { HubspotService, Progress } from '../interfaces';
 
 export default class LiveHubspotService implements HubspotService {
 
-  private client = new hubspot.Client(env.hubspot.accessToken
-    ? { accessToken: env.hubspot.accessToken }
-    : { apiKey: env.hubspot.apiKey });
+  private client: hubspot.Client;
+
+  constructor(creds: HubspotCreds) {
+    this.client = new hubspot.Client(creds);
+  }
 
   public async downloadEntities(_progess: Progress, kind: EntityKind, apiProperties: string[], inputAssociations: string[]): Promise<FullEntity[]> {
     let associations = ((inputAssociations.length > 0)

--- a/src/lib/io/live/marketplace.ts
+++ b/src/lib/io/live/marketplace.ts
@@ -1,13 +1,15 @@
 import got from 'got';
 import { DateTime, Duration, Interval } from 'luxon';
 import { RawLicense, RawTransaction } from '../../model/marketplace/raw';
-import env from '../../parameters/env-config';
+import { MpacCreds } from '../../parameters/interfaces';
 import { AttachableError, KnownError } from '../../util/errors';
 import cache from '../cache';
 import { MarketplaceService, Progress } from '../interfaces';
 
 
 export class LiveMarketplaceService implements MarketplaceService {
+
+  constructor(private creds: MpacCreds) { }
 
   public async downloadTransactions(): Promise<RawTransaction[]> {
     const transactions = await this.downloadMarketplaceData('/sales/transactions/export');
@@ -33,9 +35,9 @@ export class LiveMarketplaceService implements MarketplaceService {
   }
 
   private async downloadMarketplaceData<T>(subpath: string): Promise<T[]> {
-    const res = await got.get(`https://marketplace.atlassian.com/rest/2/vendors/${env.mpac.sellerId}/reporting${subpath}`, {
+    const res = await got.get(`https://marketplace.atlassian.com/rest/2/vendors/${this.creds.sellerId}/reporting${subpath}`, {
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(env.mpac.user + ':' + env.mpac.apiKey).toString('base64'),
+        'Authorization': 'Basic ' + Buffer.from(this.creds.user + ':' + this.creds.apiKey).toString('base64'),
       },
     });
 

--- a/src/lib/io/slack.ts
+++ b/src/lib/io/slack.ts
@@ -1,15 +1,12 @@
 import * as slack from '@slack/web-api';
 import log from '../log/logger';
-import env from '../parameters/env-config';
 
 export default class Slack {
 
   private client?: slack.WebClient;
 
-  public constructor() {
-    if (env.slack.apiToken) {
-      this.client = new slack.WebClient(env.slack.apiToken);
-    }
+  public constructor(apiToken: string, private errorChannelId: string | undefined) {
+    this.client = new slack.WebClient(apiToken);
   }
 
   public async postErrorToSlack(text: string) {
@@ -19,9 +16,9 @@ export default class Slack {
   public async postAttachmentToSlack({ title, content }: { title: string, content: string }) {
     log.info('Slack', title, content);
 
-    if (env.slack.errorChannelId) {
+    if (this.errorChannelId) {
       await this.client?.files.upload({
-        channels: env.slack.errorChannelId,
+        channels: this.errorChannelId,
         title: title,
         content: content,
       })
@@ -31,9 +28,9 @@ export default class Slack {
   public async postToSlack(text: string) {
     log.info('Slack', text);
 
-    if (env.slack.errorChannelId) {
+    if (this.errorChannelId) {
       await this.client?.chat.postMessage({
-        channel: env.slack.errorChannelId,
+        channel: this.errorChannelId,
         text: text,
       });
     }

--- a/src/lib/model/database.ts
+++ b/src/lib/model/database.ts
@@ -4,7 +4,7 @@ import { MultiDownloadLogger } from "../log/download-logger";
 import log from "../log/logger";
 import { Table } from "../log/table";
 import { Tallier } from "../log/tallier";
-import { Config } from "../parameters/env-config";
+import env, { Config } from "../parameters/env-config";
 import { formatMoney, formatNumber } from "../util/formatters";
 import { CompanyManager } from "./company";
 import { ContactManager } from "./contact";
@@ -34,7 +34,10 @@ export class Database {
 
   public tallier = new Tallier();
 
-  public constructor(private io: IO, config: Config) {
+  public appToPlatform: { [addonKey: string]: string } = Object.create(null);
+  public archivedApps = new Set<string>();
+
+  public constructor(private io: IO, config: Config, populateFromEnv = true) {
     this.dealManager = new DealManager(io.in.hubspot, io.out.hubspot);
     this.contactManager = new ContactManager(io.in.hubspot, io.out.hubspot);
     this.companyManager = new CompanyManager(io.in.hubspot, io.out.hubspot);
@@ -43,6 +46,15 @@ export class Database {
     for (const domain of config.partnerDomains) {
       this.partnerDomains.add(domain);
     }
+
+    if (populateFromEnv) {
+      this.populateFromEnv();
+    }
+  }
+
+  populateFromEnv() {
+    this.appToPlatform = env.mpac.platforms;
+    this.archivedApps = env.engine.archivedApps;
   }
 
   public async downloadAllData() {

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -33,8 +33,6 @@ type DealComputed = {
 
 export class Deal extends Entity<DealData, DealComputed> {
 
-  records: (License | Transaction)[] = [];
-
   public contacts = this.makeDynamicAssociation<Contact>('contact');
   public companies = this.makeDynamicAssociation<Company>('company');
 

--- a/src/lib/model/marketplace/record.ts
+++ b/src/lib/model/marketplace/record.ts
@@ -10,6 +10,8 @@ export abstract class MpacRecord<T> {
   public partnerContact: Contact | null = null;
   public allContacts: Contact[] = [];
 
+  public partnerDomain: string | null = null;
+
   public constructor(public data: T) { }
 
   public getPartnerDomain(partnerDomains: Set<string>) {

--- a/src/lib/parameters/env-config.ts
+++ b/src/lib/parameters/env-config.ts
@@ -124,7 +124,6 @@ function requireOneOf<T>(opts: T[]): T {
   })));
 
   const firstValid = all.find(opt => opt.value);
-  if (isTest) return opts[0];
   assert.ok(firstValid, `One of ENV keys ${all.map(o => o.envKey).join(' or ')} are required`);
 
   const { localKey, value } = firstValid;

--- a/src/lib/parameters/env-config.ts
+++ b/src/lib/parameters/env-config.ts
@@ -28,6 +28,13 @@ export function serviceCredsFromENV() {
   }
 }
 
+export function slackConfigFromENV() {
+  return {
+    apiToken: optional('SLACK_API_TOKEN'),
+    errorChannelId: optional('SLACK_ERROR_CHANNEL_ID'),
+  };
+}
+
 const env = {
   mpac: {
     platforms: Object.fromEntries<string>(
@@ -75,11 +82,6 @@ const env = {
         associatedPartner: optional('HUBSPOT_DEAL_ASSOCIATED_PARTNER'),
       },
     },
-  },
-
-  slack: {
-    apiToken: optional('SLACK_API_TOKEN'),
-    errorChannelId: optional('SLACK_ERROR_CHANNEL_ID'),
   },
 
   loop: {

--- a/src/lib/parameters/env-config.ts
+++ b/src/lib/parameters/env-config.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import dotenv from "dotenv";
+import { HubspotCreds, MpacCreds } from "./interfaces";
 
 dotenv.config();
 
@@ -10,11 +11,25 @@ export interface Config {
   partnerDomains: string[];
 }
 
+export function serviceCredsFromENV() {
+  return {
+
+    mpacCreds: {
+      user: required('MPAC_USER'),
+      apiKey: required('MPAC_API_KEY'),
+      sellerId: required('MPAC_SELLER_ID'),
+    } as MpacCreds,
+
+    hubspotCreds: requireOneOf([
+      { accessToken: 'HUBSPOT_ACCESS_TOKEN' },
+      { apiKey: 'HUBSPOT_API_KEY' },
+    ]) as HubspotCreds,
+
+  }
+}
+
 const env = {
   mpac: {
-    user: required('MPAC_USER'),
-    apiKey: required('MPAC_API_KEY'),
-    sellerId: required('MPAC_SELLER_ID'),
     platforms: Object.fromEntries<string>(
       required('ADDONKEY_PLATFORMS')
         .split(',')
@@ -23,10 +38,6 @@ const env = {
   },
 
   hubspot: {
-    ...requireOneOf([
-      { accessToken: 'HUBSPOT_ACCESS_TOKEN' },
-      { apiKey: 'HUBSPOT_API_KEY' },
-    ]),
     accountId: optional('HUBSPOT_ACCOUNT_ID'),
     pipeline: {
       mpac: required('HUBSPOT_PIPELINE_MPAC'),

--- a/src/lib/parameters/env-config.ts
+++ b/src/lib/parameters/env-config.ts
@@ -35,6 +35,14 @@ export function slackConfigFromENV() {
   };
 }
 
+export function runLoopConfigFromENV() {
+  return {
+    runInterval: required('RUN_INTERVAL'),
+    retryInterval: required('RETRY_INTERVAL'),
+    retryTimes: +required('RETRY_TIMES'),
+  };
+}
+
 const env = {
   mpac: {
     platforms: Object.fromEntries<string>(
@@ -82,12 +90,6 @@ const env = {
         associatedPartner: optional('HUBSPOT_DEAL_ASSOCIATED_PARTNER'),
       },
     },
-  },
-
-  loop: {
-    runInterval: required('RUN_INTERVAL'),
-    retryInterval: required('RETRY_INTERVAL'),
-    retryTimes: +required('RETRY_TIMES'),
   },
 
   engine: {

--- a/src/lib/parameters/env-config.ts
+++ b/src/lib/parameters/env-config.ts
@@ -71,12 +71,15 @@ const env = {
     errorChannelId: optional('SLACK_ERROR_CHANNEL_ID'),
   },
 
-  engine: {
+  loop: {
     runInterval: required('RUN_INTERVAL'),
     retryInterval: required('RETRY_INTERVAL'),
     retryTimes: +required('RETRY_TIMES'),
+  },
+
+  engine: {
     partnerDomains: optional('PARTNER_DOMAINS')?.split(/\s*,\s*/g),
-    ignoredApps: new Set(optional('IGNORED_APPS')?.split(',') ?? []),
+    archivedApps: new Set(optional('IGNORED_APPS')?.split(',') ?? []),
     ignoredEmails: new Set((optional('IGNORED_EMAILS')?.split(',') ?? []).map(e => e.toLowerCase())),
   },
 };

--- a/src/lib/parameters/interfaces.ts
+++ b/src/lib/parameters/interfaces.ts
@@ -1,0 +1,12 @@
+
+export interface MpacCreds {
+  user: string,
+  apiKey: string,
+  sellerId: string,
+}
+
+export type HubspotCreds = {
+  accessToken: string,
+} | {
+  apiKey: string,
+};

--- a/src/lib/util/runner.ts
+++ b/src/lib/util/runner.ts
@@ -1,14 +1,19 @@
 import log from "../log/logger";
-import env from "../parameters/env-config";
 
-export default async function run({ work, failed }: {
+interface LoopConfig {
+  runInterval: string,
+  retryInterval: string,
+  retryTimes: number,
+};
+
+export default async function run(loopConfig: LoopConfig, { work, failed }: {
   work: () => Promise<void>,
   failed: (errors: Error[]) => Promise<void>,
 }) {
-  log.info('Runner', 'Starting with options:', env.loop);
-  const normalInterval = env.loop.runInterval;
-  const errorInterval = env.loop.retryInterval;
-  const errorTries = env.loop.retryTimes;
+  log.info('Runner', 'Starting with options:', loopConfig);
+  const normalInterval = loopConfig.runInterval;
+  const errorInterval = loopConfig.retryInterval;
+  const errorTries = loopConfig.retryTimes;
 
   log.info('Runner', 'Running loop');
   const errors: Error[] = [];

--- a/src/lib/util/runner.ts
+++ b/src/lib/util/runner.ts
@@ -5,10 +5,10 @@ export default async function run({ work, failed }: {
   work: () => Promise<void>,
   failed: (errors: Error[]) => Promise<void>,
 }) {
-  log.info('Runner', 'Starting with options:', env.engine);
-  const normalInterval = env.engine.runInterval;
-  const errorInterval = env.engine.retryInterval;
-  const errorTries = env.engine.retryTimes;
+  log.info('Runner', 'Starting with options:', env.loop);
+  const normalInterval = env.loop.runInterval;
+  const errorInterval = env.loop.retryInterval;
+  const errorTries = env.loop.retryTimes;
 
   log.info('Runner', 'Running loop');
   const errors: Error[] = [];


### PR DESCRIPTION
This fixes #70 by updating the reporting summary.

It also updates the previous engine behavior which wasn't letting partner-only transactions get through to the deal-generator phase, so that deals are created for them now, and marked as closed-won, but with "Associated Partner" set.

Oh I also did a tiny bit of work towards moving ENV stuff out of the engine logic, so that tests can run without having ENV variables set (ie. in GH/CI). There's more work towards that, but I wasn't going to put this PR off for that.

It also corrects the implementation of the associated partners, which was slightly wrong.