### PR TITLE
Prepare SEN replacements

### DIFF
--- a/docs/HUBSPOT.md
+++ b/docs/HUBSPOT.md
@@ -18,14 +18,16 @@ Add any of these fields in HubSpot, and assign their internal IDs to an ENV var:
 
 ### Deals
 
-| Field              | Type        | Allowed Values             | ENV var                              | Required |
-| ------------------ | ----------- | -------------------------- | ------------------------------------ | -------- |
-| License Tier       | Number      | *                          | `HUBSPOT_DEAL_LICENSE_TIER_ATTR`     | ❌        |
-| Related Products   | 1-Select    | `DEAL_RELATED_PRODUCTS`    | `HUBSPOT_DEAL_RELATED_PRODUCTS_ATTR` | ❌        |
-| Origin             | 1-Select    | `DEAL_ORIGIN`              | `HUBSPOT_DEAL_ORIGIN_ATTR`           | ❌        |
-| Deployment         | 1-Select    | "hosting" of MPAC records  | `HUBSPOT_DEAL_DEPLOYMENT_ATTR`       | ❌        |
-| App                | 1-Select    | "addonKey" of MPAC records | `HUBSPOT_DEAL_APP_ATTR`              | ❌        |
-| Country            | 1-line Text | "country" of MPAC records  | `HUBSPOT_DEAL_COUNTRY_ATTR`          | ❌        |
-| AddonLicenseId     | 1-line Text | (for engine use)           | `HUBSPOT_DEAL_ADDONLICENESID_ATTR`   | ✔️        |
-| TransactionId      | 1-line Text | (for engine use)           | `HUBSPOT_DEAL_TRANSACTIONID_ATTR`    | ✔️        |
-| Associated Partner | 1-line Text | Valid domains              | `HUBSPOT_DEAL_ASSOCIATED_PARTNER`    | ❌        |
+| Field                | Type        | Allowed Values             | ENV var                                  | Required |
+| -------------------- | ----------- | -------------------------- | ---------------------------------------- | -------- |
+| License Tier         | Number      | *                          | `HUBSPOT_DEAL_LICENSE_TIER_ATTR`         | ❌        |
+| Related Products     | 1-Select    | `DEAL_RELATED_PRODUCTS`    | `HUBSPOT_DEAL_RELATED_PRODUCTS_ATTR`     | ❌        |
+| Origin               | 1-Select    | `DEAL_ORIGIN`              | `HUBSPOT_DEAL_ORIGIN_ATTR`               | ❌        |
+| Deployment           | 1-Select    | "hosting" of MPAC records  | `HUBSPOT_DEAL_DEPLOYMENT_ATTR`           | ❌        |
+| App                  | 1-Select    | "addonKey" of MPAC records | `HUBSPOT_DEAL_APP_ATTR`                  | ❌        |
+| Country              | 1-line Text | "country" of MPAC records  | `HUBSPOT_DEAL_COUNTRY_ATTR`              | ❌        |
+| Associated Partner   | 1-line Text | Valid domains              | `HUBSPOT_DEAL_ASSOCIATED_PARTNER`        | ❌        |
+| AddonLicenseId       | 1-line Text | (for engine use)           | `HUBSPOT_DEAL_ADDONLICENESID_ATTR`       | ✔️        |
+| TransactionId        | 1-line Text | (for engine use)           | `HUBSPOT_DEAL_TRANSACTIONID_ATTR`        | ✔️        |
+| AppEntitlementId     | 1-line Text | (for engine use)           | `HUBSPOT_DEAL_APPENTITLEMENTID_ATTR`     | ✔️        |
+| AppEntitlementNumber | 1-line Text | (for engine use)           | `HUBSPOT_DEAL_APPENTITLEMENTNUMBER_ATTR` | ✔️        |

--- a/src/lib/engine/deal-generator/actions.ts
+++ b/src/lib/engine/deal-generator/actions.ts
@@ -275,6 +275,8 @@ function dealCreationProperties(records: (License | Transaction)[], record: Lice
     dealName: mustache.render(env.hubspot.deals.dealDealName, record.data),
     pipeline: Pipeline.MPAC,
     associatedPartner,
+    appEntitlementId: record.data.appEntitlementId,
+    appEntitlementNumber: record.data.appEntitlementNumber,
     amount: (data.dealStage === DealStage.EVAL
       ? null
       : record instanceof License

--- a/src/lib/engine/deal-generator/redact.ts
+++ b/src/lib/engine/deal-generator/redact.ts
@@ -8,6 +8,9 @@ import { Transaction } from '../../model/transaction';
 export function redactedLicense(t: License): License {
   return new License({
     addonLicenseId: t.data.addonLicenseId,
+    appEntitlementId: t.data.addonLicenseId,
+    appEntitlementNumber: t.data.addonLicenseId,
+
     licenseId: t.data.licenseId,
     addonKey: Redact.addonKey(t.data.addonKey),
     addonName: Redact.addonName(t.data.addonName),
@@ -39,6 +42,9 @@ export function redactedLicense(t: License): License {
 export function redactedTransaction(t: Transaction): Transaction {
   return new Transaction({
     addonLicenseId: t.data.addonLicenseId,
+    appEntitlementId: t.data.addonLicenseId,
+    appEntitlementNumber: t.data.addonLicenseId,
+
     licenseId: t.data.licenseId,
     addonKey: Redact.addonKey(t.data.addonKey),
     addonName: Redact.addonName(t.data.addonName),

--- a/src/lib/engine/deal-generator/test/test-cases/smoke.test.ts
+++ b/src/lib/engine/deal-generator/test/test-cases/smoke.test.ts
@@ -25,6 +25,8 @@ it(`Sets deal properties correctly`, () => {
         maintenanceEndDate: '2013-12-27',
         status: 'inactive',
         evaluationOpportunitySize: 'NA',
+        appEntitlementId: 'abc',
+        appEntitlementNumber: '123',
         attribution: null,
         parentInfo: null,
         newEvalData: null

--- a/src/lib/engine/deal-generator/test/utils.ts
+++ b/src/lib/engine/deal-generator/test/utils.ts
@@ -152,6 +152,9 @@ export function testLicense(
 function testRecordCommon(addonLicenseId: string, maintenanceStartDate: string, email?: string) {
   return {
     addonLicenseId,
+    appEntitlementId: addonLicenseId,
+    appEntitlementNumber: addonLicenseId,
+
     licenseId: addonLicenseId,
     addonKey: chance.word({ capitalize: false, syllables: 3 }),
     addonName: chance.sentence({ words: 3, punctuation: false }),

--- a/src/lib/model/database.ts
+++ b/src/lib/model/database.ts
@@ -6,6 +6,7 @@ import { Table } from "../log/table";
 import { Tallier } from "../log/tallier";
 import env, { Config } from "../parameters/env-config";
 import { formatMoney, formatNumber } from "../util/formatters";
+import { isPresent } from "../util/helpers";
 import { CompanyManager } from "./company";
 import { ContactManager } from "./contact";
 import { DealManager } from "./deal";
@@ -113,6 +114,8 @@ export class Database {
     this.licenses = results.licenses.map(raw => License.fromRaw(raw));
     this.transactions = results.transactions.map(raw => Transaction.fromRaw(raw));
 
+    this.validateIdUniqueness();
+
     const transactionTotal = (this.transactions
       .map(t => t.data.vendorAmount)
       .reduce((a, b) => a + b));
@@ -173,4 +176,59 @@ export class Database {
     }
   }
 
+  private validateIdUniqueness() {
+    log.info('Database', 'Validating MPAC ID uniqueness: Starting...')
+
+    // All three should be unique on licenses
+    verifyIdIsUnique(this.licenses, l => l.data.addonLicenseId);
+    verifyIdIsUnique(this.licenses, l => l.data.appEntitlementId);
+    verifyIdIsUnique(this.licenses, l => l.data.appEntitlementNumber);
+
+    // All license IDs should point to the same transactions
+    for (const l of this.licenses) {
+      const id1 = l.data.appEntitlementId;
+      const id2 = l.data.appEntitlementNumber;
+      const id3 = l.data.addonLicenseId;
+
+      const array1 = id1 && this.transactions.filter(t => id1 === t.data.appEntitlementId);
+      const array2 = id2 && this.transactions.filter(t => id2 === t.data.appEntitlementNumber);
+      const array3 = id3 && this.transactions.filter(t => id3 === t.data.addonLicenseId);
+
+      const set1 = array1 && uniqueSetFor(array1);
+      const set2 = array2 && uniqueSetFor(array2);
+      const set3 = array3 && uniqueSetFor(array3);
+
+      verifySameSet(set1 || null, set2 || null);
+      verifySameSet(set2 || null, set3 || null);
+    }
+
+    log.info('Database', 'Validating MPAC ID uniqueness: Done')
+  }
+
+}
+
+function verifyIdIsUnique(licenses: License[], getter: (r: License) => string | null) {
+  const ids = licenses.map(getter).filter(isPresent);
+  const idSet = new Set(ids);
+  if (ids.length !== idSet.size) {
+    const idName = getter.toString().replace(/(\w+) => \1\.data\./, '');
+    log.error('Database', 'License IDs not unique:', idName);
+  }
+}
+
+function uniqueSetFor(transactions: Transaction[]) {
+  const set = new Set(transactions);
+  if (set.size !== transactions.length) {
+    log.error('Database', `Transactions aren't unique: got ${set.size} out of ${transactions.length}`);
+  }
+  return set;
+}
+
+function verifySameSet(set1: Set<Transaction> | null, set2: Set<Transaction> | null) {
+  if (!set1 || !set2) return;
+
+  const same = set1.size === set2.size && [...set1].every(t => set2.has(t));
+  if (!same) {
+    log.error('Database', `License IDs do not point to same transactions`);
+  }
 }

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -24,6 +24,9 @@ export type DealData = {
   dealStage: DealStage;
   amount: number | null;
   associatedPartner: string | null;
+
+  appEntitlementId: string | null;
+  appEntitlementNumber: string | null;
 };
 
 type DealComputed = {
@@ -146,6 +149,16 @@ const DealAdapter: EntityAdapter<DealData, DealComputed> = {
       property: env.hubspot.attrs.deal.associatedPartner,
       down: partner => partner || null,
       up: partner => partner ?? '',
+    },
+    appEntitlementId: {
+      property: env.hubspot.attrs.deal.appEntitlementId,
+      down: id => id || null,
+      up: id => id ?? '',
+    },
+    appEntitlementNumber: {
+      property: env.hubspot.attrs.deal.appEntitlementNumber,
+      down: id => id || null,
+      up: id => id ?? '',
     },
   },
 

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -39,15 +39,19 @@ export class Deal extends Entity<DealData, DealComputed> {
   public contacts = this.makeDynamicAssociation<Contact>('contact');
   public companies = this.makeDynamicAssociation<Company>('company');
 
-  public mpacId() {
-    if (this.data.transactionId && this.data.addonLicenseId) {
+  public mpacId() { return this.deriveId(this.data.addonLicenseId); }
+  public entitlementId() { return this.deriveId(this.data.appEntitlementId); }
+  public entitlementNumber() { return this.deriveId(this.data.appEntitlementNumber); }
+
+  public deriveId(id: string | null) {
+    if (this.data.transactionId && id) {
       return uniqueTransactionId({
         transactionId: this.data.transactionId,
-        addonLicenseId: this.data.addonLicenseId,
+        addonLicenseId: id,
       });
     }
     else {
-      return this.data.addonLicenseId;
+      return id;
     }
   }
 
@@ -205,12 +209,18 @@ export class DealManager extends EntityManager<DealData, DealComputed, Deal> {
 
   /** Either `License.addonLicenseId` or `Transaction.transactionId[Transacton.addonLicenseId]` */
   public getByMpacId = this.makeIndex(d => [d.mpacId()].filter(isPresent), ['transactionId', 'addonLicenseId']);
+  public getByEntitlementId = this.makeIndex(d => [d.entitlementId()].filter(isPresent), ['transactionId', 'appEntitlementId']);
+  public getByEntitlementNumber = this.makeIndex(d => [d.entitlementNumber()].filter(isPresent), ['transactionId', 'appEntitlementNumber']);
 
   public duplicatesToDelete = new Map<Deal, Set<Deal>>();
 
   public getDealsForRecords(records: (License | Transaction)[]) {
     return new Set(records
-      .map(record => this.getByMpacId(record.id))
+      .flatMap(record => [
+        this.getByEntitlementNumber(record.id),
+        this.getByEntitlementId(record.id),
+        this.getByMpacId(record.id),
+      ])
       .filter(isPresent));
   }
 

--- a/src/lib/model/license.ts
+++ b/src/lib/model/license.ts
@@ -30,6 +30,9 @@ type NewEvalData = {
 
 export interface LicenseData {
   addonLicenseId: AddonLicenseId,
+  appEntitlementId: string | null,
+  appEntitlementNumber: string | null,
+
   licenseId: string,
   addonKey: string,
   addonName: string,
@@ -93,6 +96,9 @@ export class License extends MpacRecord<LicenseData> {
 
     return new License({
       addonLicenseId: rawLicense.addonLicenseId,
+      appEntitlementId: rawLicense.appEntitlementId ?? null,
+      appEntitlementNumber: rawLicense.appEntitlementNumber ?? null,
+
       licenseId: rawLicense.licenseId,
       addonKey: rawLicense.addonKey,
       addonName: rawLicense.addonName,

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -6,6 +6,9 @@ import { MpacRecord } from "./marketplace/record";
 
 export interface TransactionData {
   addonLicenseId: AddonLicenseId,
+  appEntitlementId: string | null,
+  appEntitlementNumber: string | null,
+
   licenseId: string,
   addonKey: string,
   addonName: string,
@@ -49,6 +52,9 @@ export class Transaction extends MpacRecord<TransactionData> {
       transactionId: rawTransaction.transactionId,
 
       addonLicenseId: rawTransaction.addonLicenseId,
+      appEntitlementId: rawTransaction.appEntitlementId ?? null,
+      appEntitlementNumber: rawTransaction.appEntitlementNumber ?? null,
+
       licenseId: rawTransaction.licenseId,
       addonKey: rawTransaction.addonKey,
       addonName: rawTransaction.addonName,

--- a/src/lib/parameters/env-config.ts
+++ b/src/lib/parameters/env-config.ts
@@ -83,6 +83,8 @@ const env = {
         origin: optional('HUBSPOT_DEAL_ORIGIN_ATTR'),
         country: optional('HUBSPOT_DEAL_COUNTRY_ATTR'),
         deployment: optional('HUBSPOT_DEAL_DEPLOYMENT_ATTR'),
+        appEntitlementId: required('HUBSPOT_DEAL_APPENTITLEMENTID_ATTR'),
+        appEntitlementNumber: required('HUBSPOT_DEAL_APPENTITLEMENTNUMBER_ATTR'),
         addonLicenseId: required('HUBSPOT_DEAL_ADDONLICENESID_ATTR'),
         transactionId: required('HUBSPOT_DEAL_TRANSACTIONID_ATTR'),
         licenseTier: optional('HUBSPOT_DEAL_LICENSE_TIER_ATTR'),


### PR DESCRIPTION
After this PR is merged, HubSpot deals will be updated to have the 2 new IDs when present, and MAE will try to use these to look up deals before using SEN.

This PR does half of #16. This doesn't finish the SEN-replacement feature, though. The engine assumes addonLicenseId is always present.

So we'll need to do one more PR after this, to replace this assumption in the engine with these new assumptions:

1. AddonLicenseId may sometimes be missing
2. Entitlement{Id,Number} may sometimes be present
3. Ostensibly, after SEN is removed, these will be mutually exclusive, so either 1 or 2 is present, but never both
4. Until SEN is removed, there will be SEN and possibly ENT2. (I'm just gonna call them both ENT2 from now on.)

@bberenberg when you get a second, please let me know if these assumptions look right to you. (We'll always have assertions in the code to verify assumptions like these.)
