### PR TITLE
Finish SEN replacement

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Run cached-download",
+      "name": "Dry-run",
       "request": "launch",
       "skipFiles": [
         "<node_internals>/**"
@@ -19,21 +19,15 @@
       "type": "pwa-node"
     },
     {
-      "name": "Run cached-download multiple times",
+      "name": "Dry-run 3x",
       "request": "launch",
       "skipFiles": [
         "<node_internals>/**"
       ],
-      "program": "${workspaceFolder}/src/bin/verify-multiple-runs.ts",
-      "type": "pwa-node"
-    },
-    {
-      "name": "Downloader",
-      "program": "${workspaceFolder}/src/bin/download.ts",
-      "request": "launch",
-      "skipFiles": [
-        "<node_internals>/**"
+      "args": [
+        "--skiplogs=true"
       ],
+      "program": "${workspaceFolder}/src/bin/run-3x.ts",
       "type": "pwa-node"
     },
     {

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ $ npm run build # either build once
 $ npm run watch # or watch and build
 $ npm test
 
-# Run engine multiple times,
+# Run engine 3 times,
 #   starting with cached data,
 #   and pumping output of each run
 #     into input of next run
-$ npm run multiple
+$ npm run 3x
 
 # Explain what the engine does given certain SENs or transactions
 # (Requires the engine to have been run on latest data locally)
@@ -101,7 +101,9 @@ To save logs about what the scoring engine is doing during a dry-run, pass a sub
 - Refunded deals now have their amounts set to zero.
 - Purchased inactive licenses are set to closed-won if not refunded.
 - Added `--savelogs=somedir` as the way to manually log debug files.
-- Updated `npm run multiple` to save logs to `data/run{1..3}/`.
+- Renamed `npm run multiple` to `npm run 3x`.
+- Updated `npm run 3x` to save logs to `data/run{1..3}/`.
+- Added (optional) `--skiplogs=true` option to `npm run 3x`.
 - Sped up license scorer down to 12% original run time in some cases.
 - Removed `--cached-fns` option and cached-fns data file usage.
 

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -79,9 +79,9 @@ After this, the engine has a combination of all existing and new Contacts, ready
 
 This phase assumes a few things:
 
-1. Each `addonLicenseId` uniquely points to exactly one License
-2. Each transaction points to exactly one `addonLicenseId`
-3. Some transactions point to the same `addonLicenseId`
+1. Each license is a unique object within MPAC data
+2. Each transaction points to exactly one license
+3. Some transactions point to the same license
 4. Therefore, we can match up every license with 0-N transactions
 5. Each license keeps a reference to all its transactions (as an array)
 6. Each transaction keeps a reference to its license

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "tsc --watch",
     "once": "node out/bin/run-once.js",
     "generate-test": "node out/bin/generate-test.js",
-    "multiple": "node out/bin/verify-multiple-runs.js",
+    "3x": "node out/bin/run-3x.js",
     "download": "node out/bin/download.js",
     "entitlements": "node out/bin/entitlements.js",
     "test": "jest",

--- a/src/bin/generate-test.ts
+++ b/src/bin/generate-test.ts
@@ -80,7 +80,7 @@ main(template, testId);
 function abbrRecordDetails(record: License | Transaction) {
   if (record instanceof Transaction) {
     return `testTransaction(${[
-      record.data.addonLicenseId,
+      record.id,
       record.data.saleDate,
       record.data.licenseType,
       record.data.saleType,
@@ -92,7 +92,7 @@ function abbrRecordDetails(record: License | Transaction) {
   }
   else {
     return `testLicense(${[
-      record.data.addonLicenseId,
+      record.id,
       record.data.maintenanceStartDate,
       record.data.licenseType,
       record.data.status,

--- a/src/bin/run-3x.ts
+++ b/src/bin/run-3x.ts
@@ -10,6 +10,9 @@ import { envConfig } from '../lib/parameters/env-config';
 main();
 async function main() {
 
+  const skiplogs = cli.get('--skiplogs');
+  const logdir = (dir: string) => skiplogs ? null : new DataDir(dir);
+
   cli.failIfExtraOpts();
   log.level = log.Levels.Info;
 
@@ -17,13 +20,13 @@ async function main() {
   const engine = new Engine();
 
   // First
-  await engine.run(new Database(io, envConfig), new DataDir('run1'));
+  await engine.run(new Database(io, envConfig), logdir('run1'));
 
   // Second
   log.level = log.Levels.Verbose;
-  await engine.run(new Database(io, envConfig), new DataDir('run2'));
+  await engine.run(new Database(io, envConfig), logdir('run2'));
 
   // Third
-  await engine.run(new Database(io, envConfig), new DataDir('run3'));
+  await engine.run(new Database(io, envConfig), logdir('run3'));
 
 }

--- a/src/lib/engine/deal-generator/test/utils.ts
+++ b/src/lib/engine/deal-generator/test/utils.ts
@@ -185,7 +185,7 @@ export function abbrActionDetails(action: Action) {
     case 'create': return {
       "Create": {
         dealStage: DealStage[action.properties.dealStage],
-        addonLicenseId: action.properties.addonLicenseId,
+        addonLicenseId: action.properties.addonLicenseId ?? action.properties.appEntitlementId ?? action.properties.appEntitlementNumber!,
         transactionId: action.properties.transactionId,
         closeDate: action.properties.closeDate,
         amount: action.properties.amount,

--- a/src/lib/engine/license-matching/license-grouper.ts
+++ b/src/lib/engine/license-matching/license-grouper.ts
@@ -146,7 +146,7 @@ export class LicenseGrouper {
 
 export function shorterLicenseInfo(license: License) {
   return {
-    addonLicenseId: license.data.addonLicenseId,
+    id: license.id,
 
     company: license.data.company,
 

--- a/src/lib/model/database.ts
+++ b/src/lib/model/database.ts
@@ -221,14 +221,14 @@ export class Database {
       log.warn('Scoring Engine', "The following transactions have no accompanying licenses:");
       {
         const table = new Table([{ title: 'Refunds' }, { title: 'License', align: 'right' }]);
-        for (const tx of refunds) { table.rows.push([tx.data.transactionId, tx.data.addonLicenseId ?? tx.data.appEntitlementId ?? tx.data.appEntitlementNumber!]); }
+        for (const tx of refunds) { table.rows.push([tx.data.transactionId, tx.id]); }
         for (const row of table.eachRow()) {
           log.warn('Scoring Engine', '  ' + row);
         }
       }
       {
         const table = new Table([{ title: 'Maybe Refunded' }, { title: 'License', align: 'right' }]);
-        for (const tx of maybeRefunded) { table.rows.push([tx.data.transactionId, tx.data.addonLicenseId ?? tx.data.appEntitlementId ?? tx.data.appEntitlementNumber!]); }
+        for (const tx of maybeRefunded) { table.rows.push([tx.data.transactionId, tx.id]); }
         for (const row of table.eachRow()) {
           log.warn('Scoring Engine', '  ' + row);
         }

--- a/src/lib/model/database.ts
+++ b/src/lib/model/database.ts
@@ -105,14 +105,19 @@ export class Database {
     this.providerDomains = this.emailProviderLister.set;
 
     const emailRe = makeEmailValidationRegex(tlds);
+
+    const licenses = [
+      ...licensesWithDataInsights,
+      ...licensesWithoutDataInsights,
+    ].map(raw => License.fromRaw(raw));
+
     const results = validateMarketplaceData(
-      licensesWithDataInsights,
-      licensesWithoutDataInsights,
-      transactions,
+      licenses,
+      transactions.map(raw => Transaction.fromRaw(raw)),
       emailRe);
 
-    this.licenses = results.licenses.map(raw => License.fromRaw(raw));
-    this.transactions = results.transactions.map(raw => Transaction.fromRaw(raw));
+    this.licenses = results.licenses;
+    this.transactions = results.transactions;
 
     log.info('Database', 'Connecting MPAC records: Starting...');
     this.buildMpacMappings();

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -93,7 +93,7 @@ const DealAdapter: EntityAdapter<DealData, DealComputed> = {
     addonLicenseId: {
       property: env.hubspot.attrs.deal.addonLicenseId,
       identifier: true,
-      down: addonLicenseId => addonLicenseId!,
+      down: addonLicenseId => addonLicenseId,
       up: addonLicenseId => addonLicenseId || '',
     },
     transactionId: {

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -93,14 +93,14 @@ const DealAdapter: EntityAdapter<DealData, DealComputed> = {
     addonLicenseId: {
       property: env.hubspot.attrs.deal.addonLicenseId,
       identifier: true,
-      down: addonLicenseId => addonLicenseId,
-      up: addonLicenseId => addonLicenseId || '',
+      down: id => id || null,
+      up: id => id || '',
     },
     transactionId: {
       property: env.hubspot.attrs.deal.transactionId,
       identifier: true,
-      down: transactionId => transactionId,
-      up: transactionId => transactionId || '',
+      down: id => id || null,
+      up: id => id || '',
     },
     closeDate: {
       property: 'closedate',

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -154,11 +154,13 @@ const DealAdapter: EntityAdapter<DealData, DealComputed> = {
     },
     appEntitlementId: {
       property: env.hubspot.attrs.deal.appEntitlementId,
+      identifier: true,
       down: id => id || null,
       up: id => id ?? '',
     },
     appEntitlementNumber: {
       property: env.hubspot.attrs.deal.appEntitlementNumber,
+      identifier: true,
       down: id => id || null,
       up: id => id ?? '',
     },

--- a/src/lib/model/license.ts
+++ b/src/lib/model/license.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { AddonLicenseId, ContactInfo, getContactInfo, getPartnerInfo, maybeGetContactInfo, PartnerInfo } from "./marketplace/common";
+import { ContactInfo, getContactInfo, getPartnerInfo, maybeGetContactInfo, PartnerInfo } from "./marketplace/common";
 import { RawLicense } from "./marketplace/raw";
 import { MpacRecord } from './marketplace/record.js';
 import { Transaction } from './transaction';
@@ -29,7 +29,7 @@ type NewEvalData = {
 };
 
 export interface LicenseData {
-  addonLicenseId: AddonLicenseId | null,
+  addonLicenseId: string | null,
   appEntitlementId: string | null,
   appEntitlementNumber: string | null,
 
@@ -131,7 +131,11 @@ export class License extends MpacRecord<LicenseData> {
 
   public constructor(data: LicenseData) {
     super(data);
-    this.id = this.data.addonLicenseId ?? this.data.appEntitlementId ?? this.data.appEntitlementNumber!;
+    this.id = (
+      this.data.addonLicenseId ??
+      this.data.appEntitlementId ??
+      this.data.appEntitlementNumber!
+    );
     this.tier = Math.max(this.parseTier(), this.tierFromEvalOpportunity());
     this.active = this.data.status === 'active';
   }

--- a/src/lib/model/license.ts
+++ b/src/lib/model/license.ts
@@ -29,7 +29,7 @@ type NewEvalData = {
 };
 
 export interface LicenseData {
-  addonLicenseId: AddonLicenseId,
+  addonLicenseId: AddonLicenseId | null,
   appEntitlementId: string | null,
   appEntitlementNumber: string | null,
 
@@ -95,7 +95,7 @@ export class License extends MpacRecord<LicenseData> {
     }
 
     return new License({
-      addonLicenseId: rawLicense.addonLicenseId,
+      addonLicenseId: rawLicense.addonLicenseId ?? null,
       appEntitlementId: rawLicense.appEntitlementId ?? null,
       appEntitlementNumber: rawLicense.appEntitlementNumber ?? null,
 

--- a/src/lib/model/marketplace/common.ts
+++ b/src/lib/model/marketplace/common.ts
@@ -1,7 +1,5 @@
 import { RawLicenseContact, RawPartnerDetails, RawTransactionContact } from "./raw";
 
-export type AddonLicenseId = string | null;
-
 export type ContactInfo = {
   email: string,
   name?: string,

--- a/src/lib/model/marketplace/raw.ts
+++ b/src/lib/model/marketplace/raw.ts
@@ -14,7 +14,7 @@ export type RawPartnerDetails = {
 
 export interface RawTransaction {
   transactionId: string;
-  addonLicenseId: string;
+  addonLicenseId?: string;
   licenseId: string;
   addonKey: string;
   addonName: string;
@@ -57,7 +57,7 @@ export type RawLicenseContact = {
 };
 
 export interface RawLicense {
-  addonLicenseId: string;
+  addonLicenseId?: string;
   licenseId: string;
   addonKey: string;
   addonName: string;

--- a/src/lib/model/marketplace/validation.ts
+++ b/src/lib/model/marketplace/validation.ts
@@ -52,14 +52,23 @@ function uniqLicenses(licenses: RawLicense[]) {
   const edgeCases = Object.values(groups).filter(ls => ls.length > 1);
   for (const dups of edgeCases) {
     assert.ok(dups
-      .map(({
-        attribution, evaluationOpportunitySize,
-        parentProductBillingCycle, parentProductName,
-        installedOnSandbox, parentProductEdition,
-        evaluationLicense, evaluationSaleDate,
-        evaluationStartDate, evaluationEndDate,
-        daysToConvertEval,
-        ...dup }) => dup)
+      .map(dup => ({
+        addonKey: dup.addonKey,
+        addonName: dup.addonName,
+        contactDetails: dup.contactDetails,
+        hosting: dup.hosting,
+        lastUpdated: dup.lastUpdated,
+        licenseId: dup.licenseId,
+        licenseType: dup.licenseType,
+        maintenanceEndDate: dup.maintenanceEndDate,
+        maintenanceStartDate: dup.maintenanceStartDate,
+        status: dup.status,
+        tier: dup.tier,
+        addonLicenseId: dup.addonLicenseId,
+        appEntitlementId: dup.appEntitlementId,
+        appEntitlementNumber: dup.appEntitlementNumber,
+        partnerDetails: dup.partnerDetails,
+      }) as Partial<RawLicense>)
       .every((dup, i, array) => util.isDeepStrictEqual(dup, array[0])),
       util.inspect(dups, { colors: true, depth: null })
     );

--- a/src/lib/model/marketplace/validation.ts
+++ b/src/lib/model/marketplace/validation.ts
@@ -122,7 +122,8 @@ function validateField<T>(o: T, accessor: (o: T) => any) {
 
 function filterLicensesWithTechEmail(license: RawLicense) {
   if (!license.contactDetails.technicalContact?.email) {
-    log.warn('Downloader', 'License does not have a tech contact email; will be skipped', license.addonLicenseId);
+    const id = license.addonLicenseId ?? license.appEntitlementId ?? license.appEntitlementNumber!;
+    log.warn('Downloader', 'License does not have a tech contact email; will be skipped', id);
     return false;
   }
   return true;

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -5,7 +5,7 @@ import { RawTransaction } from "./marketplace/raw";
 import { MpacRecord } from "./marketplace/record";
 
 export interface TransactionData {
-  addonLicenseId: AddonLicenseId,
+  addonLicenseId: AddonLicenseId | null,
   appEntitlementId: string | null,
   appEntitlementNumber: string | null,
 
@@ -51,7 +51,7 @@ export class Transaction extends MpacRecord<TransactionData> {
     return new Transaction({
       transactionId: rawTransaction.transactionId,
 
-      addonLicenseId: rawTransaction.addonLicenseId,
+      addonLicenseId: rawTransaction.addonLicenseId ?? null,
       appEntitlementId: rawTransaction.appEntitlementId ?? null,
       appEntitlementNumber: rawTransaction.appEntitlementNumber ?? null,
 

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -1,11 +1,11 @@
 import assert from "assert";
 import { License } from "./license";
-import { AddonLicenseId, ContactInfo, getContactInfo, getPartnerInfo, maybeGetContactInfo, PartnerInfo } from "./marketplace/common";
+import { ContactInfo, getContactInfo, getPartnerInfo, maybeGetContactInfo, PartnerInfo } from "./marketplace/common";
 import { RawTransaction } from "./marketplace/raw";
 import { MpacRecord } from "./marketplace/record";
 
 export interface TransactionData {
-  addonLicenseId: AddonLicenseId | null,
+  addonLicenseId: string | null,
   appEntitlementId: string | null,
   appEntitlementNumber: string | null,
 

--- a/src/lib/util/helpers.ts
+++ b/src/lib/util/helpers.ts
@@ -18,13 +18,3 @@ export function sorter<T>(fn: (o: T) => string | number, dir: 'ASC' | 'DSC' = 'A
     fn(a) < fn(b) ? down : up
   );
 }
-
-export function split<T>(array: T[], inFirstArray: (o: T) => boolean): [T[], T[]] {
-  const first: T[] = [];
-  const second: T[] = [];
-  for (const item of array) {
-    const which = (inFirstArray(item) ? first : second);
-    which.push(item);
-  }
-  return [first, second];
-}


### PR DESCRIPTION
A few places needed to be updated that were missed:

- [x] A few docs
- [x] A few TypeScript types
- [x] A few test utils and logs
- [x] A few undefined's that should be nulls
- [x] The license cutoff de-duplicator
- [x] Fixed HubSpot ident serialization of `transactionId` and `addonLicenseId`
- [x] Made 2 new IDs also be used when mapping back HubSpot entity-creation results