### PR TITLE
Analyzes data across data sets, and reports to Slack

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -68,3 +68,6 @@ DEAL_DEALNAME={{{addonName}}} at {{{company}}}
 # How many data sets to keep
 # E.g. daily for 8 days, weekly for 5 weeks, monthly for 2 months
 KEEP_DATA_SETS=8d 5w 2m
+
+# How many days late a transaction can appear before reporting it to Slack.
+LATE_TRANSACTION_THRESHOLD_DAYS=30

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ $ node out/bin/main.js  # This always uses live inputs/outputs
 
 ## Changelog
 
+### Unreleased
+
+- Added `KEEP_DATA_SETS` ENV variable.
+- Added `LATE_TRANSACTION_THRESHOLD_DAYS` ENV variable.
+- Added `npm run analyze-data-shift` task.
+- Main loop now analyzes and reports on data shift.
+
 ### 0.3.0
 
 - Docker image now requires persistent `./data` directory

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ node out/bin/main.js  # This always uses live inputs/outputs
 
 ## Changelog
 
-### Unreleased
+### 0.4.0
 
 - Added `KEEP_DATA_SETS` ENV variable.
 - Added `LATE_TRANSACTION_THRESHOLD_DAYS` ENV variable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1759,9 +1759,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001252",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+      "version": "1.0.30001309",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
+      "integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -6804,9 +6804,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001252",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
-      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
+      "version": "1.0.30001309",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
+      "integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==",
       "dev": true
     },
     "capitalize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marketing-automation-engine",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "marketing-automation-engine",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "@hubspot/api-client": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marketing-automation-engine",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "",
   "main": "out/bin/main.js",
   "scripts": {

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -1,33 +1,6 @@
 import 'source-map-support/register';
+import { DataShiftAnalyzer } from '../lib/data-shift/analyze';
 import { dataManager } from '../lib/data/manager';
-import { ConsoleLogger } from '../lib/log/console';
-import { License } from '../lib/model/license';
 
-const console = new ConsoleLogger();
-
-console.printInfo('Analyze Data Shift', `Starting...`);
-const [firstDataset, ...dataSets] = dataManager.allDataSets();
-console.printInfo('Analyze Data Shift', `Loaded.`);
-
-console.printInfo('Analyze Data Shift', `Preparing initial licenses`);
-const licensesById = new Map<string, License>();
-for (const license of firstDataset.mpac.licenses) {
-  licensesById.set(license.id, license);
-}
-console.printInfo('Analyze Data Shift', `Done.`);
-
-console.printInfo('Analyze Data Shift', `Analyzing license data shift`);
-for (const ds of dataSets) {
-
-  for (const license of ds.mpac.licenses) {
-    const found = licensesById.get(license.id);
-    if (!found) {
-      console.printWarning('Analyze Data Shift', 'License went missing:', {
-        timestampChecked: ds.timestamp,
-        license: license.id,
-      });
-    }
-  }
-
-}
-console.printInfo('Analyze Data Shift', `Done.`);
+const analyzer = new DataShiftAnalyzer();
+analyzer.run(dataManager.allDataSets());

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -15,61 +15,58 @@ const dataSets = dataManager.allDataSetIds().sort().map(id => {
 });
 console.printInfo('Data Shift Analyzer', 'Loading data sets: Done');
 
-const analyzer = new DataShiftAnalyzer(console, issues => {
-
-  if (issues.alteredRecords.length === 0) {
-    console.printInfo('Data Shift Analyzer', 'No altered records found');
-  }
-  else {
-    issues.alteredRecords.sort(sorter(JSON.stringify));
-    Table.print({
-      title: 'Altered Records',
-      log: str => console.printWarning('Data Shift Analyzer', str),
-      cols: [
-        [{ title: 'Kind' }, row => row.kind],
-        [{ title: 'ID' }, row => row.id],
-        [{ title: 'Field' }, row => row.key],
-        [{ title: 'Value' }, row => row.val],
-        [{ title: 'Last Value' }, row => row.lastVal],
-      ],
-      rows: issues.alteredRecords,
-    });
-  }
-
-  if (issues.deletedRecords.length === 0) {
-    console.printInfo('Data Shift Analyzer', 'No deleted records found');
-  }
-  else {
-    issues.deletedRecords.sort(sorter(JSON.stringify));
-    Table.print({
-      title: 'Deleted Records',
-      log: str => console.printWarning('Data Shift Analyzer', str),
-      cols: [
-        [{ title: 'Kind' }, row => row.kind],
-        [{ title: 'ID' }, row => row.id],
-        [{ title: 'Timestamp' }, row => row.timestampChecked],
-      ],
-      rows: issues.deletedRecords,
-    });
-  }
-
-  if (issues.lateTransactions.length === 0) {
-    console.printInfo('Data Shift Analyzer', 'No late transactions found');
-  }
-  else {
-    issues.lateTransactions.sort(sorter(JSON.stringify));
-    Table.print({
-      title: 'Late Transactions',
-      log: str => console.printWarning('Data Shift Analyzer', str),
-      cols: [
-        [{ title: 'ID' }, row => row.id],
-        [{ title: 'Date Expected' }, row => row.expected],
-        [{ title: 'Date Found' }, row => row.found],
-      ],
-      rows: issues.lateTransactions,
-    });
-  }
-
-});
-
+const analyzer = new DataShiftAnalyzer(console);
 analyzer.run(dataSets);
+
+if (analyzer.alteredRecords.length === 0) {
+  console.printInfo('Data Shift Analyzer', 'No altered records found');
+}
+else {
+  analyzer.alteredRecords.sort(sorter(JSON.stringify));
+  Table.print({
+    title: 'Altered Records',
+    log: str => console.printWarning('Data Shift Analyzer', str),
+    cols: [
+      [{ title: 'Kind' }, row => row.kind],
+      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Field' }, row => row.key],
+      [{ title: 'Value' }, row => row.val],
+      [{ title: 'Last Value' }, row => row.lastVal],
+    ],
+    rows: analyzer.alteredRecords,
+  });
+}
+
+if (analyzer.deletedRecords.length === 0) {
+  console.printInfo('Data Shift Analyzer', 'No deleted records found');
+}
+else {
+  analyzer.deletedRecords.sort(sorter(JSON.stringify));
+  Table.print({
+    title: 'Deleted Records',
+    log: str => console.printWarning('Data Shift Analyzer', str),
+    cols: [
+      [{ title: 'Kind' }, row => row.kind],
+      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Timestamp' }, row => row.timestampChecked],
+    ],
+    rows: analyzer.deletedRecords,
+  });
+}
+
+if (analyzer.lateTransactions.length === 0) {
+  console.printInfo('Data Shift Analyzer', 'No late transactions found');
+}
+else {
+  analyzer.lateTransactions.sort(sorter(JSON.stringify));
+  Table.print({
+    title: 'Late Transactions',
+    log: str => console.printWarning('Data Shift Analyzer', str),
+    cols: [
+      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Date Expected' }, row => row.expected],
+      [{ title: 'Date Found' }, row => row.found],
+    ],
+    rows: analyzer.lateTransactions,
+  });
+}

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -1,64 +1,15 @@
 import 'source-map-support/register';
 import { DataShiftAnalyzer } from '../lib/data-shift/analyze';
-import { dataManager } from '../lib/data/manager';
+import { loadDataSets } from '../lib/data-shift/loader';
+import { DataShiftReporter } from '../lib/data-shift/reporter';
 import { ConsoleLogger } from '../lib/log/console';
-import { Table } from '../lib/log/table';
-import { sorter } from '../lib/util/helpers';
 
 const console = new ConsoleLogger();
-console.printInfo('Data Shift Analyzer', 'Loading data sets: Starting...');
-const dataSets = dataManager.allDataSetIds().sort().map(id => {
-  console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Starting...`);
-  const ds = dataManager.dataSetFrom(id);
-  console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Done`);
-  return ds;
-});
-console.printInfo('Data Shift Analyzer', 'Loading data sets: Done');
+
+const dataSets = loadDataSets(console);
 
 const analyzer = new DataShiftAnalyzer(console);
 const results = analyzer.run(dataSets);
 
-reportResult('Altered Licenses', results.alteredLicenses, [
-  [{ title: 'ID' }, row => row.id],
-  [{ title: 'Field' }, row => row.key],
-  [{ title: 'Value' }, row => row.val],
-  [{ title: 'Last Value' }, row => row.lastVal],
-]);
-
-reportResult('Altered Transactions', results.alteredTransactions, [
-  [{ title: 'ID' }, row => row.id],
-  [{ title: 'Field' }, row => row.key],
-  [{ title: 'Value' }, row => row.val],
-  [{ title: 'Last Value' }, row => row.lastVal],
-]);
-
-reportResult('Deleted Licenses', results.deletedLicenses, [
-  [{ title: 'ID' }, row => row.id],
-  [{ title: 'Timestamp' }, row => row.timestampChecked],
-]);
-
-reportResult('Deleted Transactions', results.deletedTransactions, [
-  [{ title: 'ID' }, row => row.id],
-  [{ title: 'Timestamp' }, row => row.timestampChecked],
-]);
-
-reportResult('Late Transactions', results.lateTransactions, [
-  [{ title: 'ID' }, row => row.id],
-  [{ title: 'Date Expected' }, row => row.expected],
-  [{ title: 'Date Found' }, row => row.found],
-]);
-
-function reportResult<T>(resultKind: string, resultItems: T[], colSpecs: [{ title: string }, (t: T) => string][]) {
-  if (resultItems.length === 0) {
-    console.printInfo('Data Shift Analyzer', `No ${resultKind} found`);
-  }
-  else {
-    resultItems.sort(sorter(JSON.stringify));
-    Table.print({
-      title: resultKind,
-      log: str => console.printWarning('Data Shift Analyzer', str),
-      cols: colSpecs,
-      rows: resultItems,
-    });
-  }
-}
+const reporter = new DataShiftReporter(console);
+reporter.report(results);

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -16,57 +16,49 @@ const dataSets = dataManager.allDataSetIds().sort().map(id => {
 console.printInfo('Data Shift Analyzer', 'Loading data sets: Done');
 
 const analyzer = new DataShiftAnalyzer(console);
-analyzer.run(dataSets);
+const results = analyzer.run(dataSets);
 
-if (analyzer.alteredRecords.length === 0) {
-  console.printInfo('Data Shift Analyzer', 'No altered records found');
-}
-else {
-  analyzer.alteredRecords.sort(sorter(JSON.stringify));
-  Table.print({
-    title: 'Altered Records',
-    log: str => console.printWarning('Data Shift Analyzer', str),
-    cols: [
-      [{ title: 'Kind' }, row => row.kind],
-      [{ title: 'ID' }, row => row.id],
-      [{ title: 'Field' }, row => row.key],
-      [{ title: 'Value' }, row => row.val],
-      [{ title: 'Last Value' }, row => row.lastVal],
-    ],
-    rows: analyzer.alteredRecords,
-  });
-}
+reportResult('Altered Licenses', results.alteredLicenses, [
+  [{ title: 'ID' }, row => row.id],
+  [{ title: 'Field' }, row => row.key],
+  [{ title: 'Value' }, row => row.val],
+  [{ title: 'Last Value' }, row => row.lastVal],
+]);
 
-if (analyzer.deletedRecords.length === 0) {
-  console.printInfo('Data Shift Analyzer', 'No deleted records found');
-}
-else {
-  analyzer.deletedRecords.sort(sorter(JSON.stringify));
-  Table.print({
-    title: 'Deleted Records',
-    log: str => console.printWarning('Data Shift Analyzer', str),
-    cols: [
-      [{ title: 'Kind' }, row => row.kind],
-      [{ title: 'ID' }, row => row.id],
-      [{ title: 'Timestamp' }, row => row.timestampChecked],
-    ],
-    rows: analyzer.deletedRecords,
-  });
-}
+reportResult('Altered Transactions', results.alteredTransactions, [
+  [{ title: 'ID' }, row => row.id],
+  [{ title: 'Field' }, row => row.key],
+  [{ title: 'Value' }, row => row.val],
+  [{ title: 'Last Value' }, row => row.lastVal],
+]);
 
-if (analyzer.lateTransactions.length === 0) {
-  console.printInfo('Data Shift Analyzer', 'No late transactions found');
-}
-else {
-  analyzer.lateTransactions.sort(sorter(JSON.stringify));
-  Table.print({
-    title: 'Late Transactions',
-    log: str => console.printWarning('Data Shift Analyzer', str),
-    cols: [
-      [{ title: 'ID' }, row => row.id],
-      [{ title: 'Date Expected' }, row => row.expected],
-      [{ title: 'Date Found' }, row => row.found],
-    ],
-    rows: analyzer.lateTransactions,
-  });
+reportResult('Deleted Licenses', results.deletedLicenses, [
+  [{ title: 'ID' }, row => row.id],
+  [{ title: 'Timestamp' }, row => row.timestampChecked],
+]);
+
+reportResult('Deleted Transactions', results.deletedTransactions, [
+  [{ title: 'ID' }, row => row.id],
+  [{ title: 'Timestamp' }, row => row.timestampChecked],
+]);
+
+reportResult('Late Transactions', results.lateTransactions, [
+  [{ title: 'ID' }, row => row.id],
+  [{ title: 'Date Expected' }, row => row.expected],
+  [{ title: 'Date Found' }, row => row.found],
+]);
+
+function reportResult<T>(resultKind: string, resultItems: T[], colSpecs: [{ title: string }, (t: T) => string][]) {
+  if (resultItems.length === 0) {
+    console.printInfo('Data Shift Analyzer', `No ${resultKind} found`);
+  }
+  else {
+    resultItems.sort(sorter(JSON.stringify));
+    Table.print({
+      title: resultKind,
+      log: str => console.printWarning('Data Shift Analyzer', str),
+      cols: colSpecs,
+      rows: resultItems,
+    });
+  }
 }

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -5,7 +5,7 @@ import { ConsoleLogger } from '../lib/log/console';
 
 const console = new ConsoleLogger();
 console.printInfo('Data Shift Analyzer', 'Loading data sets: Starting...');
-const dataSets = dataManager.allDataSetIds().map(id => {
+const dataSets = dataManager.allDataSetIds().sort().map(id => {
   console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Starting...`);
   const ds = dataManager.dataSetFrom(id);
   console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Done`);

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -2,6 +2,7 @@ import 'source-map-support/register';
 import { DataShiftAnalyzer } from '../lib/data-shift/analyze';
 import { dataManager } from '../lib/data/manager';
 import { ConsoleLogger } from '../lib/log/console';
+import { Table } from '../lib/log/table';
 import { sorter } from '../lib/util/helpers';
 
 const console = new ConsoleLogger();
@@ -15,7 +16,60 @@ const dataSets = dataManager.allDataSetIds().sort().map(id => {
 console.printInfo('Data Shift Analyzer', 'Loading data sets: Done');
 
 const analyzer = new DataShiftAnalyzer(console, issues => {
-  issues.sort(sorter(JSON.stringify));
-  console.printWarning('Data Shift Analyzer', issues);
+
+  if (issues.alteredRecords.length === 0) {
+    console.printInfo('Data Shift Analyzer', 'No altered records found');
+  }
+  else {
+    issues.alteredRecords.sort(sorter(JSON.stringify));
+    Table.print({
+      title: 'Altered Records',
+      log: str => console.printWarning('Data Shift Analyzer', str),
+      cols: [
+        [{ title: 'Kind' }, row => row.kind],
+        [{ title: 'ID' }, row => row.id],
+        [{ title: 'Field' }, row => row.key],
+        [{ title: 'Value' }, row => row.val],
+        [{ title: 'Last Value' }, row => row.lastVal],
+      ],
+      rows: issues.alteredRecords,
+    });
+  }
+
+  if (issues.deletedRecords.length === 0) {
+    console.printInfo('Data Shift Analyzer', 'No deleted records found');
+  }
+  else {
+    issues.deletedRecords.sort(sorter(JSON.stringify));
+    Table.print({
+      title: 'Deleted Records',
+      log: str => console.printWarning('Data Shift Analyzer', str),
+      cols: [
+        [{ title: 'Kind' }, row => row.kind],
+        [{ title: 'ID' }, row => row.id],
+        [{ title: 'Timestamp' }, row => row.timestampChecked],
+      ],
+      rows: issues.deletedRecords,
+    });
+  }
+
+  if (issues.lateTransactions.length === 0) {
+    console.printInfo('Data Shift Analyzer', 'No late transactions found');
+  }
+  else {
+    issues.lateTransactions.sort(sorter(JSON.stringify));
+    Table.print({
+      title: 'Late Transactions',
+      log: str => console.printWarning('Data Shift Analyzer', str),
+      cols: [
+        [{ title: 'ID' }, row => row.id],
+        [{ title: 'Date Expected' }, row => row.expected],
+        [{ title: 'Date Found' }, row => row.found],
+      ],
+      rows: issues.lateTransactions,
+    });
+  }
+
 });
+
 analyzer.run(dataSets);

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -1,6 +1,17 @@
 import 'source-map-support/register';
 import { DataShiftAnalyzer } from '../lib/data-shift/analyze';
 import { dataManager } from '../lib/data/manager';
+import { ConsoleLogger } from '../lib/log/console';
+
+const console = new ConsoleLogger();
+console.printInfo('Data Shift Analyzer', 'Loading data sets: Starting...');
+const dataSets = dataManager.allDataSetIds().map(id => {
+  console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Starting...`);
+  const ds = dataManager.dataSetFrom(id);
+  console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Done`);
+  return ds;
+});
+console.printInfo('Data Shift Analyzer', 'Loading data sets: Done');
 
 const analyzer = new DataShiftAnalyzer();
-analyzer.run(dataManager.allDataSets());
+analyzer.run(dataSets);

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -2,6 +2,7 @@ import 'source-map-support/register';
 import { DataShiftAnalyzer } from '../lib/data-shift/analyze';
 import { dataManager } from '../lib/data/manager';
 import { ConsoleLogger } from '../lib/log/console';
+import { sorter } from '../lib/util/helpers';
 
 const console = new ConsoleLogger();
 console.printInfo('Data Shift Analyzer', 'Loading data sets: Starting...');
@@ -13,5 +14,8 @@ const dataSets = dataManager.allDataSetIds().sort().map(id => {
 });
 console.printInfo('Data Shift Analyzer', 'Loading data sets: Done');
 
-const analyzer = new DataShiftAnalyzer();
+const analyzer = new DataShiftAnalyzer(console, issues => {
+  issues.sort(sorter(JSON.stringify));
+  console.printWarning('Data Shift Analyzer', issues);
+});
 analyzer.run(dataSets);

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -1,11 +1,33 @@
 import 'source-map-support/register';
 import { dataManager } from '../lib/data/manager';
 import { ConsoleLogger } from '../lib/log/console';
+import { License } from '../lib/model/license';
 
 const console = new ConsoleLogger();
 
 console.printInfo('Analyze Data Shift', `Starting...`);
+const [firstDataset, ...dataSets] = dataManager.allDataSets();
+console.printInfo('Analyze Data Shift', `Loaded.`);
 
-const dataSets = dataManager.allDataSets();
+console.printInfo('Analyze Data Shift', `Preparing initial licenses`);
+const licensesById = new Map<string, License>();
+for (const license of firstDataset.mpac.licenses) {
+  licensesById.set(license.id, license);
+}
+console.printInfo('Analyze Data Shift', `Done.`);
 
-// const datas = dataSets.map(ds => ds.dataSet.load());
+console.printInfo('Analyze Data Shift', `Analyzing license data shift`);
+for (const ds of dataSets) {
+
+  for (const license of ds.mpac.licenses) {
+    const found = licensesById.get(license.id);
+    if (!found) {
+      console.printWarning('Analyze Data Shift', 'License went missing:', {
+        timestampChecked: ds.timestamp,
+        license: license.id,
+      });
+    }
+  }
+
+}
+console.printInfo('Analyze Data Shift', `Done.`);

--- a/src/bin/analyze-data-shift.ts
+++ b/src/bin/analyze-data-shift.ts
@@ -8,7 +8,7 @@ const console = new ConsoleLogger();
 
 const dataSets = loadDataSets(console);
 
-const analyzer = new DataShiftAnalyzer(console);
+const analyzer = new DataShiftAnalyzer(undefined, console);
 const results = analyzer.run(dataSets);
 
 const reporter = new DataShiftReporter(console);

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -1,5 +1,8 @@
 import 'source-map-support/register';
 import { engineConfigFromENV, runLoopConfigFromENV } from "../lib/config/env";
+import { DataShiftAnalyzer } from '../lib/data-shift/analyze';
+import { loadDataSets } from '../lib/data-shift/loader';
+import { DataShiftReporter } from '../lib/data-shift/reporter';
 import { dataManager } from '../lib/data/manager';
 import { downloadAllData } from '../lib/engine/download';
 import { Engine } from "../lib/engine/engine";
@@ -36,6 +39,13 @@ run(console, runLoopConfig, {
 
     console.printInfo('Main', 'Writing HubSpot change log file');
     logDir.hubspotOutputLogger()?.logResults(dataSet.hubspot);
+
+    console.printInfo('Main', 'Analyzing data shift');
+    const dataSets = loadDataSets(console);
+    const analyzer = new DataShiftAnalyzer(console);
+    const results = analyzer.run(dataSets);
+    const reporter = new DataShiftReporter(console);
+    reporter.report(results);
 
     console.printInfo('Main', 'Done');
   },

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -44,7 +44,7 @@ run(console, runLoopConfig, {
     const dataSets = loadDataSets(console);
     const analyzer = new DataShiftAnalyzer(console);
     const results = analyzer.run(dataSets);
-    const reporter = new DataShiftReporter(console);
+    const reporter = new DataShiftReporter(console, notifier);
     reporter.report(results);
 
     console.printInfo('Main', 'Done');

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -1,5 +1,5 @@
 import 'source-map-support/register';
-import { engineConfigFromENV, runLoopConfigFromENV } from "../lib/config/env";
+import { dataShiftConfigFromENV, engineConfigFromENV, runLoopConfigFromENV } from "../lib/config/env";
 import { DataShiftAnalyzer } from '../lib/data-shift/analyze';
 import { loadDataSets } from '../lib/data-shift/loader';
 import { DataShiftReporter } from '../lib/data-shift/reporter';
@@ -42,7 +42,7 @@ run(console, runLoopConfig, {
 
     console.printInfo('Main', 'Analyzing data shift');
     const dataSets = loadDataSets(console);
-    const analyzer = new DataShiftAnalyzer(console);
+    const analyzer = new DataShiftAnalyzer(dataShiftConfigFromENV(), console);
     const results = analyzer.run(dataSets);
     const reporter = new DataShiftReporter(console, notifier);
     reporter.report(results);

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -13,7 +13,7 @@ const console = new ConsoleLogger();
 const uploader = new HubspotUploader(console);
 
 const runLoopConfig = runLoopConfigFromENV();
-const notifier = SlackNotifier.fromENV(new ConsoleLogger());
+const notifier = SlackNotifier.fromENV(console);
 notifier?.notifyStarting();
 
 run(console, runLoopConfig, {

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import dotenv from "dotenv";
+import { DataShiftConfig } from "../data-shift/analyze";
 import { EngineConfig } from "../engine/engine";
 import { HubspotCreds } from "../hubspot/api";
 import { MpacCreds } from "../marketplace/api";
@@ -26,6 +27,14 @@ export function mpacCredsFromENV(): MpacCreds {
     user: required('MPAC_USER'),
     apiKey: required('MPAC_API_KEY'),
     sellerId: required('MPAC_SELLER_ID'),
+  };
+}
+
+export function dataShiftConfigFromENV(): DataShiftConfig | undefined {
+  const threshold = optional('LATE_TRANSACTION_THRESHOLD_DAYS');
+  if (!threshold) return undefined;
+  return {
+    lateTransactionThresholdDays: +threshold,
   };
 }
 

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -9,7 +9,6 @@ import { MultiRecordMap } from "./multi-id-map";
 const LATE_TRANSACTION_THRESHOLD = 30;
 
 interface DeletedRecordIssue {
-  kind: string,
   id: string,
   timestampChecked: string,
 }
@@ -21,7 +20,6 @@ interface LateTransactionIssue {
 }
 
 interface AlteredRecordIssue {
-  kind: string,
   id: string,
   key: string,
   val: any,
@@ -81,7 +79,6 @@ export class DataShiftAnalyzer {
         const found = currentRecordMap.get(record);
         if (!found) {
           deletedRecords.push({
-            kind,
             id: record.id,
             timestampChecked: ds.timestamp.toISO(),
           });
@@ -159,7 +156,6 @@ export class DataShiftAnalyzer {
             const lastVal = lastData[key];
             if (val !== lastVal) {
               alteredRecords.push({
-                kind: `transaction`,
                 id: transaction.id,
                 key,
                 val,
@@ -198,7 +194,6 @@ export class DataShiftAnalyzer {
             const lastVal = lastData[key];
             if (val !== lastVal) {
               alteredRecords.push({
-                kind: `license`,
                 id: license.id,
                 key,
                 val,

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -19,7 +19,7 @@ export class DataShiftAnalyzer {
     for (const ds of remainingDataSets) {
       const currentLicenseMap = new LicenseMap(ds.mpac.licenses);
 
-      for (const license of lastLicenseMap.values()) {
+      for (const license of lastLicenseMap.allLicenses()) {
         const found = currentLicenseMap.get(license);
         if (!found) {
           this.#console.printWarning('License went missing:', {
@@ -74,8 +74,8 @@ class LicenseMap {
     );
   }
 
-  values() {
-    return this.#map.values();
+  allLicenses() {
+    return new Set(this.#map.values());
   }
 
   maybeGet(id: string | null): License | undefined {

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -8,7 +8,7 @@ export class DataShiftAnalyzer {
 
   public run(dataSets: DataSet[]) {
     this.checkForDeletedLicenses(dataSets);
-    this.checkForLicensesAddedLater(dataSets);
+    this.checkForWrongTransactionDates(dataSets);
   }
 
   private checkForDeletedLicenses([firstDataset, ...remainingDataSets]: DataSet[]) {
@@ -35,12 +35,13 @@ export class DataShiftAnalyzer {
     this.#console.printInfo(`Checking for deleted licenses: Done`);
   }
 
-  private checkForLicensesAddedLater([firstDataset, ...remainingDataSets]: DataSet[]) {
-    this.#console.printInfo(`Checking for licenses added later: Starting...`);
+  private checkForWrongTransactionDates(dataSets: DataSet[]) {
+    this.#console.printInfo(`Checking for late transactions: Starting...`);
 
+    for (const ds of [...dataSets].reverse()) {
+    }
 
-
-    this.#console.printInfo(`Checking for licenses added later: Done`);
+    this.#console.printInfo(`Checking for late transactions: Done`);
   }
 
 }

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -4,26 +4,24 @@ import { License } from "../model/license";
 
 export class DataShiftAnalyzer {
 
-  lastLicenseMap!: LicenseMap;
-
   private console;
   public constructor() {
     this.console = new LabeledConsoleLogger('Analyze Data Shift');
   }
 
-  public run([firstDataset, ...dataSets]: DataSet[]) {
-    this.prepareInitialLicenses(firstDataset);
-    this.analyzeLicensesInDataSets(dataSets);
+  public run(dataSets: DataSet[]) {
+    this.checkForDeletedLicenses(dataSets);
   }
 
-  analyzeLicensesInDataSets(dataSets: DataSet[]) {
-    this.console.printInfo(`Analyzing license data shift`);
+  private checkForDeletedLicenses([firstDataset, ...dataSets]: DataSet[]) {
+    this.console.printInfo(`Checking for deleted licenses: Starting...`);
+
+    let lastLicenseMap = new LicenseMap(firstDataset.mpac.licenses);
 
     for (const ds of dataSets) {
-
       const currentLicenseMap = new LicenseMap(ds.mpac.licenses);
 
-      for (const license of this.lastLicenseMap.values()) {
+      for (const license of lastLicenseMap.values()) {
         const found = currentLicenseMap.get(license);
         if (!found) {
           this.console.printWarning('License went missing:', {
@@ -33,17 +31,10 @@ export class DataShiftAnalyzer {
         }
       }
 
-      this.lastLicenseMap = currentLicenseMap;
-
+      lastLicenseMap = currentLicenseMap;
     }
 
-    this.console.printInfo(`Done.`);
-  }
-
-  prepareInitialLicenses(firstDataset: DataSet) {
-    this.console.printInfo(`Preparing initial licenses`);
-    this.lastLicenseMap = new LicenseMap(firstDataset.mpac.licenses);
-    this.console.printInfo(`Done.`);
+    this.console.printInfo(`Checking for deleted licenses: Done`);
   }
 
 }

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -147,7 +147,7 @@ export class DataShiftAnalyzer {
         lateTransactions.push({
           id: transaction.id,
           expected: transaction.data.saleDate,
-          found: foundDate.toISO(),
+          found: foundDate.toISODate(),
         });
       }
     }

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -7,14 +7,15 @@ export class DataShiftAnalyzer {
 
   #console = new LabeledConsoleLogger('Analyze Data Shift');
 
-  public run(dataSets: DataSet[]) {
-    this.checkForDeletedLicenses(dataSets);
-    this.checkForWrongTransactionDates(dataSets);
+  public run(dataSetsAsc: DataSet[]) {
+    this.checkForDeletedLicenses(dataSetsAsc);
+    this.checkForWrongTransactionDates(dataSetsAsc);
   }
 
-  private checkForDeletedLicenses([firstDataset, ...remainingDataSets]: DataSet[]) {
+  private checkForDeletedLicenses(dataSetsAsc: DataSet[]) {
     this.#console.printInfo(`Checking for deleted licenses: Starting...`);
 
+    const [firstDataset, ...remainingDataSets] = dataSetsAsc;
     let lastLicenseMap = new RecordMap(firstDataset.mpac.licenses);
 
     for (const ds of remainingDataSets) {
@@ -36,10 +37,23 @@ export class DataShiftAnalyzer {
     this.#console.printInfo(`Checking for deleted licenses: Done`);
   }
 
-  private checkForWrongTransactionDates(dataSets: DataSet[]) {
+  private checkForWrongTransactionDates(dataSetsAsc: DataSet[]) {
     this.#console.printInfo(`Checking for late transactions: Starting...`);
 
-    for (const ds of [...dataSets].reverse()) {
+    const dataSetsDesc = [...dataSetsAsc].reverse();
+    const transactionMap = new RecordMap<Transaction>([]);
+
+    for (const ds of dataSetsDesc) {
+      for (const transaction of ds.mpac.transactions) {
+
+        const found = transactionMap.get(transaction);
+        if (!found) transactionMap.add(transaction);
+
+
+
+
+        // transaction.data.saleDate;
+      }
     }
 
     this.#console.printInfo(`Checking for late transactions: Done`);
@@ -69,7 +83,11 @@ class RecordMap<T extends License | Transaction> {
   }
 
   get(record: T): T | undefined {
-    return (record.ids.map(id => this.maybeGet(id)).find(record => record));
+    return (record
+      .ids
+      .map(id => this.maybeGet(id))
+      .find(record => record)
+    );
   }
 
   allRecords() {

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -8,18 +8,18 @@ import { MultiRecordMap } from "./multi-id-map";
 
 const LATE_TRANSACTION_THRESHOLD = 30;
 
-interface DeletedRecordIssue {
+export interface DeletedRecordIssue {
   id: string,
   timestampChecked: string,
 }
 
-interface LateTransactionIssue {
+export interface LateTransactionIssue {
   id: string,
   expected: string,
   found: string,
 }
 
-interface AlteredRecordIssue {
+export interface AlteredRecordIssue {
   id: string,
   key: string,
   val: any,

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -38,10 +38,10 @@ export class DataShiftAnalyzer {
     return {
 
       deletedLicenses:
-        this.#checkForDeletedRecords(dataSetsAsc, 'license'),
+        this.#checkForDeletedRecords(dataSetsAsc, 'license', mpac => mpac.licenses),
 
       deletedTransactions:
-        this.#checkForDeletedRecords(dataSetsAsc, 'transaction'),
+        this.#checkForDeletedRecords(dataSetsAsc, 'transaction', mpac => mpac.transactions),
 
       lateTransactions:
         this.#checkForWrongTransactionDates(dataSetsAsc),
@@ -55,10 +55,8 @@ export class DataShiftAnalyzer {
     };
   }
 
-  #checkForDeletedRecords(dataSetsAsc: DataSet[], kind: 'license' | 'transaction') {
+  #checkForDeletedRecords<T extends License | Transaction>(dataSetsAsc: DataSet[], kind: 'license' | 'transaction', getRecords: (mpac: Marketplace) => T[]) {
     const deletedRecords: DeletedRecordIssue[] = [];
-
-    const getRecords = (mpac: Marketplace) => kind === 'license' ? mpac.licenses : mpac.transactions;
 
     this.#logStep(`Checking for deleted ${kind}s: Starting...`);
 

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -31,16 +31,6 @@ export class DataShiftAnalyzer {
         }
       }
 
-      for (const license of ds.mpac.licenses) {
-        const found = this.licensesById.get(license);
-        if (!found) {
-          this.console.printWarning('License went missing:', {
-            timestampChecked: ds.timestamp.toISO(),
-            license: license.id,
-          });
-        }
-      }
-
     }
     this.console.printInfo(`Done.`);
   }

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -4,27 +4,24 @@ import { License } from "../model/license";
 
 export class DataShiftAnalyzer {
 
-  private console;
-  public constructor() {
-    this.console = new LabeledConsoleLogger('Analyze Data Shift');
-  }
+  #console = new LabeledConsoleLogger('Analyze Data Shift');
 
   public run(dataSets: DataSet[]) {
     this.checkForDeletedLicenses(dataSets);
   }
 
-  private checkForDeletedLicenses([firstDataset, ...dataSets]: DataSet[]) {
-    this.console.printInfo(`Checking for deleted licenses: Starting...`);
+  private checkForDeletedLicenses([firstDataset, ...remainingDataSets]: DataSet[]) {
+    this.#console.printInfo(`Checking for deleted licenses: Starting...`);
 
     let lastLicenseMap = new LicenseMap(firstDataset.mpac.licenses);
 
-    for (const ds of dataSets) {
+    for (const ds of remainingDataSets) {
       const currentLicenseMap = new LicenseMap(ds.mpac.licenses);
 
       for (const license of lastLicenseMap.values()) {
         const found = currentLicenseMap.get(license);
         if (!found) {
-          this.console.printWarning('License went missing:', {
+          this.#console.printWarning('License went missing:', {
             timestampChecked: ds.timestamp.toISO(),
             license: license.id,
           });
@@ -34,21 +31,19 @@ export class DataShiftAnalyzer {
       lastLicenseMap = currentLicenseMap;
     }
 
-    this.console.printInfo(`Checking for deleted licenses: Done`);
+    this.#console.printInfo(`Checking for deleted licenses: Done`);
   }
 
 }
 
 class LabeledConsoleLogger {
 
-  console;
-  constructor(private label: string) {
-    this.console = new ConsoleLogger();
-  }
+  #console = new ConsoleLogger();
+  constructor(private label: string) { }
 
-  printInfo(...args: any[]) { this.console.printInfo(this.label, ...args); }
-  printWarning(...args: any[]) { this.console.printWarning(this.label, ...args); }
-  printError(...args: any[]) { this.console.printError(this.label, ...args); }
+  printInfo(...args: any[]) { this.#console.printInfo(this.label, ...args); }
+  printWarning(...args: any[]) { this.#console.printWarning(this.label, ...args); }
+  printError(...args: any[]) { this.#console.printError(this.label, ...args); }
 
 }
 

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -32,17 +32,12 @@ export class DataShiftAnalyzer {
 
   #logStep = (...args: any[]) => this.console?.printInfo('Analyze Data Shift', ...args);
 
-  #deletedRecords: DeletedRecordIssue[] = [];
-  #lateTransactions: LateTransactionIssue[] = [];
-  #alteredRecords: AlteredRecordIssue[] = [];
+  deletedRecords: DeletedRecordIssue[] = [];
+  lateTransactions: LateTransactionIssue[] = [];
+  alteredRecords: AlteredRecordIssue[] = [];
 
   constructor(
     private console?: ConsoleLogger,
-    private reportIssues?: (issues: {
-      deletedRecords: DeletedRecordIssue[],
-      lateTransactions: LateTransactionIssue[],
-      alteredRecords: AlteredRecordIssue[],
-    }) => void,
   ) { }
 
   public run(dataSetsAsc: DataSet[]) {
@@ -51,12 +46,6 @@ export class DataShiftAnalyzer {
     this.#checkForWrongTransactionDates(dataSetsAsc);
     this.#checkForAlteredTransactionData(dataSetsAsc);
     this.#checkForAlteredLicenseData(dataSetsAsc);
-
-    this.reportIssues?.({
-      deletedRecords: this.#deletedRecords,
-      lateTransactions: this.#lateTransactions,
-      alteredRecords: this.#alteredRecords,
-    });
   }
 
   #checkForDeletedRecords(dataSetsAsc: DataSet[], kind: 'license' | 'transaction') {
@@ -80,7 +69,7 @@ export class DataShiftAnalyzer {
       for (const [record,] of lastRecordMap.entries()) {
         const found = currentRecordMap.get(record);
         if (!found) {
-          this.#deletedRecords.push({
+          this.deletedRecords.push({
             kind,
             id: record.id,
             timestampChecked: ds.timestamp.toISO(),
@@ -117,7 +106,7 @@ export class DataShiftAnalyzer {
       }
 
       if (diff.days > LATE_TRANSACTION_THRESHOLD) {
-        this.#lateTransactions.push({
+        this.lateTransactions.push({
           id: transaction.id,
           expected: transaction.data.saleDate,
           found: foundDate.toISO(),
@@ -150,7 +139,7 @@ export class DataShiftAnalyzer {
             const val = data[key];
             const lastVal = lastData[key];
             if (val !== lastVal) {
-              this.#alteredRecords.push({
+              this.alteredRecords.push({
                 kind: `transaction`,
                 id: transaction.id,
                 key,
@@ -185,7 +174,7 @@ export class DataShiftAnalyzer {
             const val = data[key];
             const lastVal = lastData[key];
             if (val !== lastVal) {
-              this.#alteredRecords.push({
+              this.alteredRecords.push({
                 kind: `license`,
                 id: license.id,
                 key,

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -1,0 +1,47 @@
+import { DataSet } from "../data/set";
+import { ConsoleLogger } from "../log/console";
+import { License } from "../model/license";
+
+export class DataShiftAnalyzer {
+
+  private console;
+  public constructor() {
+    this.console = new ConsoleLogger();
+  }
+
+  public run([firstDataset, ...dataSets]: DataSet[]) {
+    this.console.printInfo('Analyze Data Shift', `Preparing initial licenses`);
+    const licensesById = new Map<string, License>();
+    for (const license of firstDataset.mpac.licenses) {
+      licensesById.set(license.id, license);
+    }
+    this.console.printInfo('Analyze Data Shift', `Done.`);
+
+    this.console.printInfo('Analyze Data Shift', `Analyzing license data shift`);
+    for (const ds of dataSets) {
+
+      for (const license of ds.mpac.licenses) {
+        const found = licensesById.get(license.id);
+        if (!found) {
+          this.console.printWarning('Analyze Data Shift', 'License went missing:', {
+            timestampChecked: ds.timestamp,
+            license: license.id,
+          });
+        }
+      }
+
+      for (const license of ds.mpac.licenses) {
+        const found = licensesById.get(license.id);
+        if (!found) {
+          this.console.printWarning('Analyze Data Shift', 'License went missing:', {
+            timestampChecked: ds.timestamp,
+            license: license.id,
+          });
+        }
+      }
+
+    }
+    this.console.printInfo('Analyze Data Shift', `Done.`);
+  }
+
+}

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -6,7 +6,13 @@ import { License } from "../model/license";
 import { Transaction } from "../model/transaction";
 import { MultiRecordMap } from "./multi-id-map";
 
-const LATE_TRANSACTION_THRESHOLD = 30;
+export interface DataShiftConfig {
+  lateTransactionThresholdDays: number,
+}
+
+const defaultConfig: DataShiftConfig = {
+  lateTransactionThresholdDays: 30,
+};
 
 export interface DeletedRecordIssue {
   id: string,
@@ -30,9 +36,13 @@ export class DataShiftAnalyzer {
 
   #logStep = (...args: any[]) => this.console?.printInfo('Analyze Data Shift', ...args);
 
+  config;
   constructor(
+    config?: DataShiftConfig,
     private console?: ConsoleLogger,
-  ) { }
+  ) {
+    this.config = config ?? defaultConfig;
+  }
 
   public run(dataSetsAsc: DataSet[]) {
     return {
@@ -143,7 +153,7 @@ export class DataShiftAnalyzer {
         continue;
       }
 
-      if (diff.days > LATE_TRANSACTION_THRESHOLD) {
+      if (diff.days > this.config.lateTransactionThresholdDays) {
         lateTransactions.push({
           id: transaction.id,
           expected: transaction.data.saleDate,

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -36,12 +36,12 @@ export class DataShiftAnalyzer {
 
   #logStep = (...args: any[]) => this.console?.printInfo('Analyze Data Shift', ...args);
 
-  config;
+  #config;
   constructor(
     config?: DataShiftConfig,
     private console?: ConsoleLogger,
   ) {
-    this.config = config ?? defaultConfig;
+    this.#config = config ?? defaultConfig;
   }
 
   public run(dataSetsAsc: DataSet[]) {
@@ -153,7 +153,7 @@ export class DataShiftAnalyzer {
         continue;
       }
 
-      if (diff.days > this.config.lateTransactionThresholdDays) {
+      if (diff.days > this.#config.lateTransactionThresholdDays) {
         lateTransactions.push({
           id: transaction.id,
           expected: transaction.data.saleDate,

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -24,7 +24,7 @@ export class DataShiftAnalyzer {
         const found = this.licensesById.get(license.id);
         if (!found) {
           this.console.printWarning('License went missing:', {
-            timestampChecked: ds.timestamp,
+            timestampChecked: ds.timestamp.toISO(),
             license: license.id,
           });
         }
@@ -34,7 +34,7 @@ export class DataShiftAnalyzer {
         const found = this.licensesById.get(license.id);
         if (!found) {
           this.console.printWarning('License went missing:', {
-            timestampChecked: ds.timestamp,
+            timestampChecked: ds.timestamp.toISO(),
             license: license.id,
           });
         }

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -6,24 +6,24 @@ export class DataShiftAnalyzer {
 
   private console;
   public constructor() {
-    this.console = new ConsoleLogger();
+    this.console = new LabeledConsoleLogger('Analyze Data Shift');
   }
 
   public run([firstDataset, ...dataSets]: DataSet[]) {
-    this.console.printInfo('Analyze Data Shift', `Preparing initial licenses`);
+    this.console.printInfo(`Preparing initial licenses`);
     const licensesById = new Map<string, License>();
     for (const license of firstDataset.mpac.licenses) {
       licensesById.set(license.id, license);
     }
-    this.console.printInfo('Analyze Data Shift', `Done.`);
+    this.console.printInfo(`Done.`);
 
-    this.console.printInfo('Analyze Data Shift', `Analyzing license data shift`);
+    this.console.printInfo(`Analyzing license data shift`);
     for (const ds of dataSets) {
 
       for (const license of ds.mpac.licenses) {
         const found = licensesById.get(license.id);
         if (!found) {
-          this.console.printWarning('Analyze Data Shift', 'License went missing:', {
+          this.console.printWarning('License went missing:', {
             timestampChecked: ds.timestamp,
             license: license.id,
           });
@@ -33,7 +33,7 @@ export class DataShiftAnalyzer {
       for (const license of ds.mpac.licenses) {
         const found = licensesById.get(license.id);
         if (!found) {
-          this.console.printWarning('Analyze Data Shift', 'License went missing:', {
+          this.console.printWarning('License went missing:', {
             timestampChecked: ds.timestamp,
             license: license.id,
           });
@@ -41,7 +41,20 @@ export class DataShiftAnalyzer {
       }
 
     }
-    this.console.printInfo('Analyze Data Shift', `Done.`);
+    this.console.printInfo(`Done.`);
   }
+
+}
+
+class LabeledConsoleLogger {
+
+  console;
+  constructor(private label: string) {
+    this.console = new ConsoleLogger();
+  }
+
+  printInfo(...args: any[]) { this.console.printInfo(this.label, ...args); }
+  printWarning(...args: any[]) { this.console.printWarning(this.label, ...args); }
+  printError(...args: any[]) { this.console.printError(this.label, ...args); }
 
 }

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -21,18 +21,18 @@ export class DataShiftAnalyzer {
 
     const [firstDataset, ...remainingDataSets] = dataSetsAsc;
 
-    let lastLicenseMap = new RecordMap<License, true>();
+    let lastLicenseMap = new MultiRecordMap<License, true>();
     for (const license of firstDataset.mpac.licenses) {
       lastLicenseMap.set(license, true);
     }
 
     for (const ds of remainingDataSets) {
-      const currentLicenseMap = new RecordMap<License, true>();
+      const currentLicenseMap = new MultiRecordMap<License, true>();
       for (const license of ds.mpac.licenses) {
         currentLicenseMap.set(license, true);
       }
 
-      for (const license of lastLicenseMap.allRecords()) {
+      for (const [license,] of lastLicenseMap.entries()) {
         const found = currentLicenseMap.get(license);
         if (!found) {
           this.#console.printWarning('License went missing:', {
@@ -92,44 +92,5 @@ class LabeledConsoleLogger {
   printInfo(...args: any[]) { this.#console.printInfo(this.label, ...args); }
   printWarning(...args: any[]) { this.#console.printWarning(this.label, ...args); }
   printError(...args: any[]) { this.#console.printError(this.label, ...args); }
-
-}
-
-class RecordMap<T extends License | Transaction, U> {
-
-  #keys = new Map<string, T>();
-  #map = new Map<T, U>();
-
-  public get(record: T): U | undefined {
-    const key = (record
-      .ids
-      .map(id => this.#maybeGet(id))
-      .find(record => record)
-    );
-    if (key) {
-      const val = this.#map.get(key);
-      if (val !== undefined) {
-        this.set(record, val);
-      }
-      return val;
-    }
-    return undefined;
-  }
-
-  #maybeGet(id: string | null): T | undefined {
-    if (id) return this.#keys.get(id);
-    return undefined;
-  }
-
-  public allRecords() {
-    return new Set(this.#keys.values());
-  }
-
-  public set(key: T, val: U) {
-    for (const id of key.ids) {
-      this.#keys.set(id, key);
-    }
-    this.#map.set(key, val);
-  }
 
 }

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -8,6 +8,7 @@ export class DataShiftAnalyzer {
 
   public run(dataSets: DataSet[]) {
     this.checkForDeletedLicenses(dataSets);
+    this.checkForLicensesAddedLater(dataSets);
   }
 
   private checkForDeletedLicenses([firstDataset, ...remainingDataSets]: DataSet[]) {
@@ -32,6 +33,14 @@ export class DataShiftAnalyzer {
     }
 
     this.#console.printInfo(`Checking for deleted licenses: Done`);
+  }
+
+  private checkForLicensesAddedLater([firstDataset, ...remainingDataSets]: DataSet[]) {
+    this.#console.printInfo(`Checking for licenses added later: Starting...`);
+
+
+
+    this.#console.printInfo(`Checking for licenses added later: Done`);
   }
 
 }

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -1,11 +1,10 @@
 import { DataSet } from "../data/set";
 import { ConsoleLogger } from "../log/console";
 import { License } from "../model/license";
-import { Transaction } from "../model/transaction";
 
 export class DataShiftAnalyzer {
 
-  licensesById = new MpacMap<License>();
+  licensesById = new LicenseMap();
 
   private console;
   public constructor() {
@@ -39,7 +38,7 @@ export class DataShiftAnalyzer {
     this.console.printInfo(`Preparing initial licenses`);
 
     for (const license of firstDataset.mpac.licenses) {
-      this.licensesById.addKeys(license);
+      this.licensesById.add(license);
     }
 
     this.console.printInfo(`Done.`);
@@ -60,14 +59,14 @@ class LabeledConsoleLogger {
 
 }
 
-class MpacMap<T extends License | Transaction>  {
+class LicenseMap {
 
   #m;
   constructor() {
-    this.#m = new Map<string, T>();
+    this.#m = new Map<string, License>();
   }
 
-  get(record: T): T | undefined {
+  get(record: License): License | undefined {
     return (
       this.maybeGet(record.data.addonLicenseId) ??
       this.maybeGet(record.data.appEntitlementId) ??
@@ -75,17 +74,15 @@ class MpacMap<T extends License | Transaction>  {
     );
   }
 
-  maybeGet(id: string | null): T | undefined {
+  maybeGet(id: string | null): License | undefined {
     if (id) return this.#m.get(id);
     return undefined;
   }
 
-  addKeys(record: T) {
+  add(record: License) {
     if (record.data.addonLicenseId) this.#m.set(record.data.addonLicenseId, record);
     if (record.data.appEntitlementId) this.#m.set(record.data.appEntitlementId, record);
     if (record.data.appEntitlementNumber) this.#m.set(record.data.appEntitlementNumber, record);
   }
 
 }
-
-const m = new MpacMap<Transaction>();

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -12,12 +12,12 @@ export class DataShiftAnalyzer {
   #console = new LabeledConsoleLogger('Analyze Data Shift');
 
   public run(dataSetsAsc: DataSet[]) {
-    this.checkForDeletedLicenses(dataSetsAsc);
-    this.checkForWrongTransactionDates(dataSetsAsc);
-    this.checkForAlteredData(dataSetsAsc);
+    this.#checkForDeletedLicenses(dataSetsAsc);
+    this.#checkForWrongTransactionDates(dataSetsAsc);
+    this.#checkForAlteredData(dataSetsAsc);
   }
 
-  private checkForDeletedLicenses(dataSetsAsc: DataSet[]) {
+  #checkForDeletedLicenses(dataSetsAsc: DataSet[]) {
     this.#console.printInfo(`Checking for deleted licenses: Starting...`);
 
     const [firstDataset, ...remainingDataSets] = dataSetsAsc;
@@ -49,7 +49,7 @@ export class DataShiftAnalyzer {
     this.#console.printInfo(`Checking for deleted licenses: Done`);
   }
 
-  private checkForWrongTransactionDates(dataSetsAsc: DataSet[]) {
+  #checkForWrongTransactionDates(dataSetsAsc: DataSet[]) {
     this.#console.printInfo(`Checking for late transactions: Starting...`);
 
     const dataSetsDesc = [...dataSetsAsc].reverse();
@@ -83,7 +83,7 @@ export class DataShiftAnalyzer {
     this.#console.printInfo(`Checking for late transactions: Done`);
   }
 
-  private checkForAlteredData(dataSetsAsc: DataSet[]) {
+  #checkForAlteredData(dataSetsAsc: DataSet[]) {
     this.#console.printInfo(`Checking for altered data: Starting...`);
 
     const map = new MultiRecordMap<Transaction, TransactionData>();

--- a/src/lib/data-shift/analyze.ts
+++ b/src/lib/data-shift/analyze.ts
@@ -4,24 +4,24 @@ import { License } from "../model/license";
 
 export class DataShiftAnalyzer {
 
+  licensesById = new Map<string, License>();
+
   private console;
   public constructor() {
     this.console = new LabeledConsoleLogger('Analyze Data Shift');
   }
 
   public run([firstDataset, ...dataSets]: DataSet[]) {
-    this.console.printInfo(`Preparing initial licenses`);
-    const licensesById = new Map<string, License>();
-    for (const license of firstDataset.mpac.licenses) {
-      licensesById.set(license.id, license);
-    }
-    this.console.printInfo(`Done.`);
+    this.prepareInitialLicenses(firstDataset);
+    this.analyzeLicensesInDataSets(dataSets);
+  }
 
+  analyzeLicensesInDataSets(dataSets: DataSet[]) {
     this.console.printInfo(`Analyzing license data shift`);
     for (const ds of dataSets) {
 
       for (const license of ds.mpac.licenses) {
-        const found = licensesById.get(license.id);
+        const found = this.licensesById.get(license.id);
         if (!found) {
           this.console.printWarning('License went missing:', {
             timestampChecked: ds.timestamp,
@@ -31,7 +31,7 @@ export class DataShiftAnalyzer {
       }
 
       for (const license of ds.mpac.licenses) {
-        const found = licensesById.get(license.id);
+        const found = this.licensesById.get(license.id);
         if (!found) {
           this.console.printWarning('License went missing:', {
             timestampChecked: ds.timestamp,
@@ -41,6 +41,16 @@ export class DataShiftAnalyzer {
       }
 
     }
+    this.console.printInfo(`Done.`);
+  }
+
+  prepareInitialLicenses(firstDataset: DataSet) {
+    this.console.printInfo(`Preparing initial licenses`);
+
+    for (const license of firstDataset.mpac.licenses) {
+      this.licensesById.set(license.id, license);
+    }
+
     this.console.printInfo(`Done.`);
   }
 

--- a/src/lib/data-shift/loader.ts
+++ b/src/lib/data-shift/loader.ts
@@ -3,12 +3,24 @@ import { ConsoleLogger } from "../log/console";
 
 export function loadDataSets(console: ConsoleLogger) {
   console.printInfo('Data Shift Analyzer', 'Loading data sets: Starting...');
+  console.printInfo('Data Shift Analyzer', 'Node.js Memory Usage', memoryUsage());
   const dataSets = dataManager.allDataSetIds().sort().map(id => {
     console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Starting...`);
     const ds = dataManager.dataSetFrom(id);
     console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Done`);
+    console.printInfo('Data Shift Analyzer', 'Node.js Memory Usage', memoryUsage());
     return ds;
   });
   console.printInfo('Data Shift Analyzer', 'Loading data sets: Done');
   return dataSets;
+}
+
+function memoryUsage() {
+  const mem = process.memoryUsage();
+  const used = mem.heapUsed;
+  const total = mem.heapTotal;
+  const usedStr = (used / 1024 / 1024).toFixed(2) + ' MB';
+  const totalStr = (total / 1024 / 1024).toFixed(2) + ' MB';
+  const percent = ((used / total) * 100).toFixed();
+  return `${percent}% (${usedStr} used / ${totalStr} total)`;
 }

--- a/src/lib/data-shift/loader.ts
+++ b/src/lib/data-shift/loader.ts
@@ -1,0 +1,14 @@
+import { dataManager } from "../data/manager";
+import { ConsoleLogger } from "../log/console";
+
+export function loadDataSets(console: ConsoleLogger) {
+  console.printInfo('Data Shift Analyzer', 'Loading data sets: Starting...');
+  const dataSets = dataManager.allDataSetIds().sort().map(id => {
+    console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Starting...`);
+    const ds = dataManager.dataSetFrom(id);
+    console.printInfo('Data Shift Analyzer', `Loading data set ${id}: Done`);
+    return ds;
+  });
+  console.printInfo('Data Shift Analyzer', 'Loading data sets: Done');
+  return dataSets;
+}

--- a/src/lib/data-shift/multi-id-map.ts
+++ b/src/lib/data-shift/multi-id-map.ts
@@ -4,7 +4,7 @@ export class MultiRecordMap<T extends { ids: string[] }, U> {
   #realMap = new Map<T, U>();
 
   public set(key: T, val: U) {
-    let realKeys = key.ids.map(id => this.#idsToKeys.get(id)).find(o => o);
+    let realKeys = this.#realKeysForKey(key);
     if (!realKeys) {
       realKeys = [key];
     }
@@ -20,8 +20,18 @@ export class MultiRecordMap<T extends { ids: string[] }, U> {
     this.#realMap.set(finalKey, val);
   }
 
+  public get(key: T): U | undefined {
+    const realKey = this.#realKeysForKey(key)?.[0];
+    if (!realKey) return undefined;
+    return this.#realMap.get(realKey);
+  }
+
   public entries() {
     return this.#realMap.entries();
+  }
+
+  #realKeysForKey(key: T) {
+    return key.ids.map(id => this.#idsToKeys.get(id)).find(o => o);
   }
 
 }

--- a/src/lib/data-shift/multi-id-map.ts
+++ b/src/lib/data-shift/multi-id-map.ts
@@ -1,0 +1,27 @@
+export class MultiRecordMap<T extends { ids: string[] }, U> {
+
+  #idsToKeys = new Map<string, T[]>();
+  #realMap = new Map<T, U>();
+
+  public set(key: T, val: U) {
+    let realKeys = key.ids.map(id => this.#idsToKeys.get(id)).find(o => o);
+    if (!realKeys) {
+      realKeys = [key];
+    }
+    else if (!realKeys.includes(key)) {
+      realKeys.push(key);
+    }
+
+    for (const id of key.ids) {
+      this.#idsToKeys.set(id, realKeys);
+    }
+
+    const finalKey = realKeys[0];
+    this.#realMap.set(finalKey, val);
+  }
+
+  public entries() {
+    return this.#realMap.entries();
+  }
+
+}

--- a/src/lib/data-shift/reporter.ts
+++ b/src/lib/data-shift/reporter.ts
@@ -1,0 +1,67 @@
+import { ConsoleLogger } from "../log/console";
+import { Table } from "../log/table";
+import { sorter } from "../util/helpers";
+import { AlteredRecordIssue, DeletedRecordIssue, LateTransactionIssue } from "./analyze";
+
+export class DataShiftReporter {
+
+  public constructor(
+    private console: ConsoleLogger,
+  ) { }
+
+  public report(results: {
+    deletedLicenses: DeletedRecordIssue[];
+    deletedTransactions: DeletedRecordIssue[];
+    lateTransactions: LateTransactionIssue[];
+    alteredTransactions: AlteredRecordIssue[];
+    alteredLicenses: AlteredRecordIssue[];
+  }) {
+
+    this.#reportResult('Altered Licenses', results.alteredLicenses, [
+      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Field' }, row => row.key],
+      [{ title: 'Value' }, row => row.val],
+      [{ title: 'Last Value' }, row => row.lastVal],
+    ]);
+
+    this.#reportResult('Altered Transactions', results.alteredTransactions, [
+      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Field' }, row => row.key],
+      [{ title: 'Value' }, row => row.val],
+      [{ title: 'Last Value' }, row => row.lastVal],
+    ]);
+
+    this.#reportResult('Deleted Licenses', results.deletedLicenses, [
+      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Timestamp' }, row => row.timestampChecked],
+    ]);
+
+    this.#reportResult('Deleted Transactions', results.deletedTransactions, [
+      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Timestamp' }, row => row.timestampChecked],
+    ]);
+
+    this.#reportResult('Late Transactions', results.lateTransactions, [
+      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Date Expected' }, row => row.expected],
+      [{ title: 'Date Found' }, row => row.found],
+    ]);
+
+  }
+
+  #reportResult<T>(resultKind: string, resultItems: T[], colSpecs: [{ title: string }, (t: T) => string][]) {
+    if (resultItems.length === 0) {
+      this.console.printInfo('Data Shift Analyzer', `No ${resultKind} found`);
+    }
+    else {
+      resultItems.sort(sorter(JSON.stringify));
+      Table.print({
+        title: resultKind,
+        log: str => this.console.printWarning('Data Shift Analyzer', str),
+        cols: colSpecs,
+        rows: resultItems,
+      });
+    }
+  }
+
+}

--- a/src/lib/data-shift/reporter.ts
+++ b/src/lib/data-shift/reporter.ts
@@ -20,31 +20,31 @@ export class DataShiftReporter {
   }) {
 
     this.#reportResult('Altered Licenses', results.alteredLicenses, [
-      [{ title: 'ID' }, row => row.id],
+      [{ title: 'License' }, row => row.id],
       [{ title: 'Field' }, row => row.key],
       [{ title: 'Value' }, row => row.val],
       [{ title: 'Last Value' }, row => row.lastVal],
     ]);
 
     this.#reportResult('Altered Transactions', results.alteredTransactions, [
-      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Transaction' }, row => row.id],
       [{ title: 'Field' }, row => row.key],
       [{ title: 'Value' }, row => row.val],
       [{ title: 'Last Value' }, row => row.lastVal],
     ]);
 
     this.#reportResult('Deleted Licenses', results.deletedLicenses, [
-      [{ title: 'ID' }, row => row.id],
+      [{ title: 'License' }, row => row.id],
       [{ title: 'Timestamp' }, row => row.timestampChecked],
     ]);
 
     this.#reportResult('Deleted Transactions', results.deletedTransactions, [
-      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Transaction' }, row => row.id],
       [{ title: 'Timestamp' }, row => row.timestampChecked],
     ]);
 
     this.#reportResult('Late Transactions', results.lateTransactions, [
-      [{ title: 'ID' }, row => row.id],
+      [{ title: 'Transaction' }, row => row.id],
       [{ title: 'Date Expected' }, row => row.expected],
       [{ title: 'Date Found' }, row => row.found],
     ]);

--- a/src/lib/data/csv.ts
+++ b/src/lib/data/csv.ts
@@ -28,7 +28,7 @@ export class CsvStream {
     this.stream.writeLine(','.repeat(this.keyCount - 1));
   }
 
-  static readFileFromFile(lines: Iterable<string>): unknown {
+  static readArrayFromCsvLines(lines: Iterable<string>): unknown {
     let keys: string[] | undefined;
     const array: any[] = [];
 

--- a/src/lib/data/csv.ts
+++ b/src/lib/data/csv.ts
@@ -30,16 +30,18 @@ export class CsvStream {
 
   static readArrayFromCsvLines(lines: Iterable<string>): unknown {
     let keys: string[] | undefined;
+    let unflattener!: Unflattener;
     const array: any[] = [];
 
     for (const line of lines) {
       if (!keys) {
         keys = line.split(',');
+        unflattener = new Unflattener(keys);
         continue;
       }
 
       const vals = JSON.parse(`[${line}]`);
-      const restored = unflatten(keys, vals);
+      const restored = unflattener.run(vals);
       array.push(restored);
     }
 
@@ -80,15 +82,6 @@ export class CsvStream {
     this.stream.close();
   }
 
-}
-
-const unflatteners = new Map<string, Unflattener>();
-
-function unflatten(keys: string[], vals: any[]) {
-  const unflattenerKey = keys.join(',');
-  let unflattener = unflatteners.get(unflattenerKey);
-  if (!unflattener) unflatteners.set(unflattenerKey, unflattener = new Unflattener(keys));
-  return unflattener.run(vals);
 }
 
 class Unflattener {

--- a/src/lib/data/csv.ts
+++ b/src/lib/data/csv.ts
@@ -82,24 +82,50 @@ export class CsvStream {
 
 }
 
+const unflatteners = new Map<string, Unflattener>();
+
 function unflatten(keys: string[], vals: any[]) {
-  const o = Object.create(null);
+  const unflattenerKey = keys.join(',');
+  let unflattener = unflatteners.get(unflattenerKey);
+  if (!unflattener) unflatteners.set(unflattenerKey, unflattener = new Unflattener(keys));
+  return unflattener.run(vals);
+}
 
-  for (let i = 0; i < keys.length; i++) {
-    const key = keys[i];
-    const val = vals[i];
-    if (val === undefined || val === null) continue;
+class Unflattener {
 
-    let sub = o;
-    const parts = key.split('.');
-    const last = parts.pop()!;
-    const lastKey = +last >= 0 ? +last : last;
-    const isArray = typeof lastKey === 'number';
-    for (const part of parts) {
-      sub = sub[part] ??= (isArray ? [] : Object.create(null));
+  #specs: {
+    parts: string[],
+    isArray: boolean,
+    lastKey: string | number,
+  }[] = [];
+
+  constructor(keys: string[]) {
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const parts = key.split('.');
+      const last = parts.pop()!;
+      const lastKey = +last >= 0 ? +last : last;
+      const isArray = typeof lastKey === 'number';
+      this.#specs.push({ parts, isArray, lastKey });
     }
-    sub[lastKey] = val;
   }
 
-  return o;
+  run(vals: any[]) {
+    const o = Object.create(null);
+
+    for (let i = 0; i < this.#specs.length; i++) {
+      const val = vals[i];
+      if (val === undefined || val === null) continue;
+
+      const { isArray, parts, lastKey } = this.#specs[i];
+      let sub = o;
+      for (let i = 0; i < parts.length; i++) {
+        sub = sub[parts[i]] ??= (isArray ? [] : Object.create(null));
+      }
+      sub[lastKey] = val;
+    }
+
+    return o;
+  }
+
 }

--- a/src/lib/data/file.ts
+++ b/src/lib/data/file.ts
@@ -12,7 +12,7 @@ export class DataFile<T extends readonly any[]> {
   }
 
   public readArray(): T {
-    return CsvStream.readFileFromFile(this.readLines()) as T;
+    return CsvStream.readArrayFromCsvLines(this.readLines()) as T;
   }
 
   public readLines(): Iterable<string> {

--- a/src/lib/data/manager.ts
+++ b/src/lib/data/manager.ts
@@ -37,9 +37,7 @@ class DataManager {
     return ms;
   }
 
-  public dataSetFrom(ms: number) {
-    const logger = new ConsoleLogger();
-
+  public dataSetFrom(ms: number, console?: ConsoleLogger) {
     const dirName = `in-${ms}`;
     if (!this.#meta.timestamps.includes(ms)) {
       throw new Error(`Data set [${dirName}] does not exist`);
@@ -47,11 +45,11 @@ class DataManager {
     const dataDir = DataDir.root.subdir(dirName);
     const dataStore = new DataSetStore(dataDir);
 
-    logger.printInfo('Data manager', `Loading data set from disk...`);
+    console?.printInfo('Data manager', `Loading data set from disk...`);
     const data = dataStore.load();
-    logger.printInfo('Data manager', `Done.`);
+    console?.printInfo('Data manager', `Done.`);
 
-    const dataSet = new DataSet(data, DateTime.fromMillis(ms), dataSetConfigFromENV(), logger);
+    const dataSet = new DataSet(data, DateTime.fromMillis(ms), dataSetConfigFromENV(), console);
 
     dataSet.makeLogDir = (name) => new LogDir(dataDir.subdir(name));
 
@@ -75,8 +73,8 @@ class DataManager {
     return this.dataSetFrom(this.#meta.timestamps[0]);
   }
 
-  public allDataSets() {
-    return this.#meta.timestamps.map(ts => this.dataSetFrom(ts));
+  public allDataSetIds() {
+    return this.#meta.timestamps;
   }
 
   public pruneDataSets(console: ConsoleLogger) {

--- a/src/lib/data/manager.ts
+++ b/src/lib/data/manager.ts
@@ -38,14 +38,20 @@ class DataManager {
   }
 
   public dataSetFrom(ms: number) {
+    const logger = new ConsoleLogger();
+
     const dirName = `in-${ms}`;
     if (!this.#meta.timestamps.includes(ms)) {
       throw new Error(`Data set [${dirName}] does not exist`);
     }
     const dataDir = DataDir.root.subdir(dirName);
     const dataStore = new DataSetStore(dataDir);
+
+    logger.printInfo('Data manager', `Loading data set from disk...`);
     const data = dataStore.load();
-    const dataSet = new DataSet(data, DateTime.fromMillis(ms), dataSetConfigFromENV());
+    logger.printInfo('Data manager', `Done.`);
+
+    const dataSet = new DataSet(data, DateTime.fromMillis(ms), dataSetConfigFromENV(), logger);
 
     dataSet.makeLogDir = (name) => new LogDir(dataDir.subdir(name));
 

--- a/src/lib/data/set.ts
+++ b/src/lib/data/set.ts
@@ -35,7 +35,7 @@ export class DataSet {
     this.mpac = new Marketplace(config?.mpacConfig);
 
     this.freeEmailDomains = deriveMultiProviderDomainsSet(rawData.freeDomains);
-    this.hubspot.importData(rawData);
+    this.hubspot.importData(rawData, console);
     this.mpac.importData(rawData, console);
   }
 

--- a/src/lib/data/set.ts
+++ b/src/lib/data/set.ts
@@ -30,7 +30,7 @@ export class DataSet {
 
   public makeLogDir?: (name: string) => LogDir;
 
-  public constructor(public rawData: RawDataSet, private timestamp: DateTime, private config?: DataSetConfig, console?: ConsoleLogger) {
+  public constructor(public rawData: RawDataSet, public timestamp: DateTime, private config?: DataSetConfig, console?: ConsoleLogger) {
     this.hubspot = new Hubspot(config?.hubspotConfig);
     this.mpac = new Marketplace(config?.mpacConfig);
 

--- a/src/lib/data/set.ts
+++ b/src/lib/data/set.ts
@@ -2,6 +2,7 @@ import { DateTime } from "luxon";
 import { mpacConfigFromENV } from "../config/env";
 import { deriveMultiProviderDomainsSet } from "../engine/all-free-email-providers";
 import { Hubspot, HubspotConfig, hubspotConfigFromENV } from "../hubspot/hubspot";
+import { ConsoleLogger } from "../log/console";
 import { LogDir } from "../log/logdir";
 import { Marketplace, MpacConfig } from "../marketplace/marketplace";
 import { RawDataSet } from "./raw";
@@ -29,13 +30,13 @@ export class DataSet {
 
   public makeLogDir?: (name: string) => LogDir;
 
-  public constructor(public rawData: RawDataSet, private timestamp: DateTime, private config?: DataSetConfig) {
+  public constructor(public rawData: RawDataSet, private timestamp: DateTime, private config?: DataSetConfig, console?: ConsoleLogger) {
     this.hubspot = new Hubspot(config?.hubspotConfig);
     this.mpac = new Marketplace(config?.mpacConfig);
 
     this.freeEmailDomains = deriveMultiProviderDomainsSet(rawData.freeDomains);
     this.hubspot.importData(rawData);
-    this.mpac.importData(rawData);
+    this.mpac.importData(rawData, console);
   }
 
 }

--- a/src/lib/engine/slack-notifier.ts
+++ b/src/lib/engine/slack-notifier.ts
@@ -11,12 +11,12 @@ interface RunLoopConfig {
 
 export class SlackNotifier {
 
-  static fromENV(log: ConsoleLogger) {
+  static fromENV(console: ConsoleLogger) {
     const slackConfig = slackConfigFromENV();
     if (!slackConfig.apiToken) return null;
 
     const client = new slack.WebClient(slackConfig.apiToken);
-    return new SlackNotifier(log, client, slackConfig.errorChannelId);
+    return new SlackNotifier(console, client, slackConfig.errorChannelId);
   }
 
   private constructor(

--- a/src/lib/engine/slack-notifier.ts
+++ b/src/lib/engine/slack-notifier.ts
@@ -11,7 +11,7 @@ interface RunLoopConfig {
 
 export class SlackNotifier {
 
-  static fromENV(console: ConsoleLogger) {
+  public static fromENV(console: ConsoleLogger) {
     const slackConfig = slackConfigFromENV();
     if (!slackConfig.apiToken) return null;
 
@@ -26,33 +26,33 @@ export class SlackNotifier {
   ) { }
 
   public async notifyStarting() {
-    this.postToSlack(`Starting Marketing Engine`);
+    this.#postToSlack(`Starting Marketing Engine`);
   }
 
   public async notifyErrors(loopConfig: RunLoopConfig, errors: any[]) {
-    await this.postToSlack(`Failed ${loopConfig.retryTimes} times. Below are the specific errors, in order. Trying again in ${loopConfig.runInterval}.`);
+    await this.#postToSlack(`Failed ${loopConfig.retryTimes} times. Below are the specific errors, in order. Trying again in ${loopConfig.runInterval}.`);
     for (const error of errors) {
       if (error instanceof KnownError) {
-        await this.postToSlack(error.message);
+        await this.#postToSlack(error.message);
       }
       else if (error instanceof AttachableError) {
-        await this.postErrorToSlack(error);
-        await this.postAttachmentToSlack({
+        await this.#postErrorToSlack(error);
+        await this.#postAttachmentToSlack({
           title: 'Error attachment for ^',
           content: error.attachment,
         });
       }
       else {
-        await this.postErrorToSlack(error);
+        await this.#postErrorToSlack(error);
       }
     }
   }
 
-  private async postErrorToSlack(error: Error) {
-    await this.postToSlack(`\`\`\`\n${error.stack}\n\`\`\``);
+  async #postErrorToSlack(error: Error) {
+    await this.#postToSlack(`\`\`\`\n${error.stack}\n\`\`\``);
   }
 
-  private async postAttachmentToSlack({ title, content }: { title: string, content: string }) {
+  async #postAttachmentToSlack({ title, content }: { title: string, content: string }) {
     this.console.printInfo('Slack', title, content);
 
     if (this.errorChannelId) {
@@ -64,7 +64,7 @@ export class SlackNotifier {
     }
   }
 
-  private async postToSlack(text: string) {
+  async #postToSlack(text: string) {
     this.console.printInfo('Slack', text);
 
     if (this.errorChannelId) {

--- a/src/lib/engine/slack-notifier.ts
+++ b/src/lib/engine/slack-notifier.ts
@@ -13,7 +13,7 @@ export class SlackNotifier {
 
   public static fromENV(console: ConsoleLogger) {
     const slackConfig = slackConfigFromENV();
-    if (!slackConfig.apiToken) return null;
+    if (!slackConfig.apiToken) return undefined;
 
     const client = new slack.WebClient(slackConfig.apiToken);
     return new SlackNotifier(console, client, slackConfig.errorChannelId);

--- a/src/lib/engine/slack-notifier.ts
+++ b/src/lib/engine/slack-notifier.ts
@@ -68,7 +68,7 @@ export class SlackNotifier {
         channels: this.errorChannelId,
         title: title,
         content: content,
-      })
+      });
     }
   }
 

--- a/src/lib/engine/slack-notifier.ts
+++ b/src/lib/engine/slack-notifier.ts
@@ -48,6 +48,14 @@ export class SlackNotifier {
     }
   }
 
+  public async notifyDataShiftIssues(resultLabel: string, table: string) {
+    await this.#postAttachmentToSlack({
+      title: `Data Shift Issue for ${resultLabel}:`,
+      content: table,
+    });
+
+  }
+
   async #postErrorToSlack(error: Error) {
     await this.#postToSlack(`\`\`\`\n${error.stack}\n\`\`\``);
   }

--- a/src/lib/hubspot/hubspot.ts
+++ b/src/lib/hubspot/hubspot.ts
@@ -1,5 +1,6 @@
 import { hubspotContactConfigFromENV, hubspotDealConfigFromENV } from "../config/env";
 import { RawDataSet } from "../data/raw";
+import { ConsoleLogger } from "../log/console";
 import { CompanyManager } from "../model/company";
 import { ContactManager, HubspotContactConfig } from "../model/contact";
 import { DealManager, HubspotDealConfig } from "../model/deal";
@@ -22,14 +23,18 @@ export class Hubspot {
     this.companyManager = new CompanyManager();
   }
 
-  public importData(data: RawDataSet) {
+  public importData(data: RawDataSet, console?: ConsoleLogger) {
+    console?.printInfo('Hubspot', 'Importing entities...');
     const dealPrelinks = this.dealManager.importEntities(data.rawDeals);
     const companyPrelinks = this.companyManager.importEntities(data.rawCompanies);
     const contactPrelinks = this.contactManager.importEntities(data.rawContacts);
+    console?.printInfo('Hubspot', 'Done.');
 
+    console?.printInfo('Hubspot', 'Linking entities...');
     this.dealManager.linkEntities(dealPrelinks, this);
     this.companyManager.linkEntities(companyPrelinks, this);
     this.contactManager.linkEntities(contactPrelinks, this);
+    console?.printInfo('Hubspot', 'Done.');
   }
 
   public populateFakeIds() {

--- a/src/lib/log/download.ts
+++ b/src/lib/log/download.ts
@@ -9,7 +9,7 @@ export interface Progress {
 
 export class MultiDownloadLogger {
 
-  constructor(private log: ConsoleLogger) { }
+  constructor(private console: ConsoleLogger) { }
 
   private multibar = new MultiBar({
     format: `${chalk.cyan('[{bar}]')} {name}`,
@@ -25,7 +25,7 @@ export class MultiDownloadLogger {
   private makeLine(name: string) {
     let bar = this.multibar.create(1, 0, { name });
     if (bar) return new AnimatedProgressBar(bar);
-    return new SimpleLogProgress(this.log, name);
+    return new SimpleLogProgress(this.console, name);
   }
 
   public done() {

--- a/src/lib/log/table.ts
+++ b/src/lib/log/table.ts
@@ -23,6 +23,17 @@ export class Table {
     }
   }
 
+  public static toString<T>(opts: {
+    rows: Iterable<T>,
+    cols: [ColSpec, (t: T) => string | string[]][],
+  }) {
+    const table = new Table(opts.cols.map(([spec,]) => spec));
+    for (const row of opts.rows) {
+      table.rows.push(opts.cols.map(([, fn]) => fn(row)));
+    }
+    return table.eachRow().join('\n');
+  }
+
   public rows: Row[] = [];
 
   public constructor(private colSpecs: ColSpec[]) {

--- a/src/lib/marketplace/marketplace.ts
+++ b/src/lib/marketplace/marketplace.ts
@@ -18,7 +18,7 @@ export class Marketplace {
   public constructor(private config?: MpacConfig) { }
 
   public importData(data: RawDataSet, console?: ConsoleLogger) {
-    console?.printInfo('Database', 'Validating MPAC records: Starting...');
+    console?.printInfo('MPAC', 'Validating MPAC records: Starting...');
 
     const emailRe = new RegExp(`.+@.+\\.(${data.tlds.join('|')})`);
     const emailChecker = (kind: 'License' | 'Transaction') =>
@@ -26,7 +26,7 @@ export class Marketplace {
         const allEmails = getEmailsForRecord(record);
         const allGood = allEmails.every(e => emailRe.test(e));
         if (!allGood && !allEmails.every(e => this.config?.ignoredEmails?.has(e.toLowerCase()))) {
-          console?.printWarning('Downloader', `${kind} has invalid email(s); will be skipped:`, record);
+          console?.printWarning('MPAC', `${kind} has invalid email(s); will be skipped:`, record);
         }
         return allGood;
       };
@@ -52,7 +52,7 @@ export class Marketplace {
     this.licenses = structured.licenses;
     this.transactions = structured.transactions;
 
-    console?.printInfo('Database', 'Validating MPAC records: Done');
+    console?.printInfo('MPAC', 'Validating MPAC records: Done');
   }
 
 }

--- a/src/lib/marketplace/structure.ts
+++ b/src/lib/marketplace/structure.ts
@@ -19,6 +19,12 @@ class MpacStructurer {
     const licensesByAppEntitlementId = new Map<string, License>();
     const licensesByAppEntitlementNumber = new Map<string, License>();
 
+    this.console?.printInfo('MPAC Verifier', 'Checking License Multi-ID uniqueness...');
+    this.checkIfIdIsUnique(licensesByAddonLicenseId, licensesByAppEntitlementId, licensesByAppEntitlementNumber);
+    this.checkIfIdIsUnique(licensesByAppEntitlementId, licensesByAddonLicenseId, licensesByAppEntitlementNumber);
+    this.checkIfIdIsUnique(licensesByAppEntitlementNumber, licensesByAddonLicenseId, licensesByAppEntitlementId);
+    this.console?.printInfo('MPAC Verifier', 'Done');
+
     const addLicense = (license: License, id: string | null, mapping: Map<string, License>) => {
       if (!id) return;
       const existing = mapping.get(id);
@@ -39,6 +45,12 @@ class MpacStructurer {
     const transactionsByAddonLicenseId = new Map<string, Set<Transaction>>();
     const transactionsByAppEntitlementId = new Map<string, Set<Transaction>>();
     const transactionsByAppEntitlementNumber = new Map<string, Set<Transaction>>();
+
+    this.console?.printInfo('MPAC Verifier', 'Checking Transaction Multi-ID uniqueness...');
+    this.checkIfIdIsUnique(transactionsByAddonLicenseId, transactionsByAppEntitlementId, transactionsByAppEntitlementNumber);
+    this.checkIfIdIsUnique(transactionsByAppEntitlementId, transactionsByAddonLicenseId, transactionsByAppEntitlementNumber);
+    this.checkIfIdIsUnique(transactionsByAppEntitlementNumber, transactionsByAddonLicenseId, transactionsByAppEntitlementId);
+    this.console?.printInfo('MPAC Verifier', 'Done');
 
     const addTransaction = (transaction: Transaction, id: string | null, mapping: Map<string, Set<Transaction>>) => {
       if (!id) return;
@@ -189,6 +201,14 @@ class MpacStructurer {
 
     if (license1 !== license2) {
       this.console?.printError('MPAC Verifier', `License IDs do not point to same License from Transaction`);
+    }
+  }
+
+  private checkIfIdIsUnique(a: Map<string, any>, b: Map<string, any>, c: Map<string, any>) {
+    for (const key of a.keys()) {
+      if (b.has(key) || c.has(key)) {
+        this.console?.printWarning('MPAC Verifier', 'ID is not unique:', key);
+      }
     }
   }
 

--- a/src/lib/marketplace/structure.ts
+++ b/src/lib/marketplace/structure.ts
@@ -123,7 +123,7 @@ class MpacStructurer {
     const refundedAmount = [...maybeRefunded].map(t => t.data.vendorAmount).reduce((a, b) => a + b, 0);
 
     if (-refundAmount !== refundedAmount) {
-      this.console?.printWarning('Scoring Engine', "The following transactions have no accompanying licenses:");
+      this.console?.printWarning('MPAC Verifier', "The following transactions have no accompanying licenses:");
 
       const sameById = (tx1: Transaction, tx2: Transaction, id: keyof TransactionData) => (
         tx1.data[id] && tx1.data[id] === tx2.data[id]
@@ -146,7 +146,7 @@ class MpacStructurer {
       if (refunds.size > 0) {
         Table.print({
           title: 'Refunds',
-          log: s => this.console?.printWarning('Scoring Engine', '  ' + s),
+          log: s => this.console?.printWarning('MPAC Verifier', '  ' + s),
           cols: [
             [{ title: 'Transaction[License]', align: 'right' }, tx => tx.id],
             [{ title: 'Amount', align: 'right' }, tx => formatMoney(tx.data.vendorAmount)],
@@ -158,7 +158,7 @@ class MpacStructurer {
       if (maybeRefunded.size > 0) {
         Table.print({
           title: 'Non-Refunds',
-          log: s => this.console?.printWarning('Scoring Engine', '  ' + s),
+          log: s => this.console?.printWarning('MPAC Verifier', '  ' + s),
           cols: [
             [{ title: 'Transaction[License]', align: 'right' }, tx => tx.id],
             [{ title: 'Amount', align: 'right' }, tx => formatMoney(tx.data.vendorAmount)],
@@ -180,7 +180,7 @@ class MpacStructurer {
 
     const same = set1.size === set2.size && [...set1].every(t => set2.has(t));
     if (!same) {
-      this.console?.printError('Database', `License IDs do not point to same transactions`);
+      this.console?.printError('MPAC Verifier', `License IDs do not point to same transactions`);
     }
   }
 
@@ -188,7 +188,7 @@ class MpacStructurer {
     if (!license1 || !license2) return;
 
     if (license1 !== license2) {
-      this.console?.printError('Database', `License IDs do not point to same License from Transaction`);
+      this.console?.printError('MPAC Verifier', `License IDs do not point to same License from Transaction`);
     }
   }
 

--- a/src/lib/marketplace/validation.ts
+++ b/src/lib/marketplace/validation.ts
@@ -107,7 +107,7 @@ function validateField<T>(o: T, accessor: (o: T) => any) {
 export function hasTechEmail(license: License, console?: ConsoleLogger) {
   if (!license.data.technicalContact?.email) {
     const id = license.id;
-    console?.printWarning('Downloader', 'License does not have a tech contact email; will be skipped', id);
+    console?.printWarning('MPAC', 'License does not have a tech contact email; will be skipped', id);
     return false;
   }
   return true;

--- a/src/lib/model/license.ts
+++ b/src/lib/model/license.ts
@@ -63,6 +63,8 @@ export class License extends MpacRecord<LicenseData> {
 
   /** Unique ID for this License. */
   declare id;
+  public ids: string[] = [];
+
   declare tier;
 
   public transactions: Transaction[] = [];
@@ -130,11 +132,17 @@ export class License extends MpacRecord<LicenseData> {
 
   public constructor(data: LicenseData) {
     super(data);
-    this.id = (
-      this.data.addonLicenseId ??
-      this.data.appEntitlementId ??
-      this.data.appEntitlementNumber!
-    );
+
+    const maybeAdd = (id: string | null) => {
+      if (id) this.ids.push(id);
+    };
+
+    maybeAdd(this.data.addonLicenseId);
+    maybeAdd(this.data.appEntitlementId);
+    maybeAdd(this.data.appEntitlementNumber);
+
+    this.id = this.ids.find(id => id)!;
+
     this.tier = Math.max(this.parseTier(), this.tierFromEvalOpportunity());
     this.active = this.data.status === 'active';
   }

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -41,6 +41,8 @@ export class Transaction extends MpacRecord<TransactionData> {
 
   /** Unique ID for this Transaction. */
   declare id;
+  public ids: string[] = [];
+
   declare tier;
 
   public license!: License;
@@ -83,11 +85,17 @@ export class Transaction extends MpacRecord<TransactionData> {
 
   public constructor(data: TransactionData) {
     super(data);
-    this.id = uniqueTransactionId(this.data.transactionId,
-      this.data.addonLicenseId ??
-      this.data.appEntitlementId ??
-      this.data.appEntitlementNumber!
-    );
+
+    const maybeAdd = (id: string | null) => {
+      if (id) this.ids.push(uniqueTransactionId(this.data.transactionId, id));
+    };
+
+    maybeAdd(this.data.addonLicenseId);
+    maybeAdd(this.data.appEntitlementId);
+    maybeAdd(this.data.appEntitlementNumber);
+
+    this.id = this.ids.find(id => id)!;
+
     this.tier = this.parseTier();
   }
 

--- a/src/tests/multi-id-map.test.ts
+++ b/src/tests/multi-id-map.test.ts
@@ -1,0 +1,55 @@
+import { MultiRecordMap } from "../lib/data-shift/multi-id-map";
+
+const o1a = { ids: ['a', 'b'] };
+const o1b = { ids: ['b', 'c'] };
+const o1c = { ids: ['c'] };
+const o2 = { ids: ['d'] };
+
+describe(`Multi-ID Map`, () => {
+
+  it(`Starts out empty`, () => {
+    const map = new MultiRecordMap();
+    expect([...map.entries()]).toEqual([
+    ]);
+  });
+
+  it(`Can set a single entry as normal`, () => {
+    const map = new MultiRecordMap();
+    map.set(o1a, 22);
+    expect([...map.entries()]).toEqual([
+      [o1a, 22],
+    ]);
+  });
+
+  it(`Returns the first entry when two identical are set`, () => {
+    const map = new MultiRecordMap();
+    map.set(o1a, 22);
+    map.set(o1b, 33);
+    expect([...map.entries()]).toEqual([
+      [o1a, 33],
+    ]);
+  });
+
+  it(`Returns the first entry with three identical are set`, () => {
+    const map = new MultiRecordMap();
+    map.set(o1a, 22);
+    map.set(o1b, 33);
+    map.set(o1c, 44);
+    expect([...map.entries()]).toEqual([
+      [o1a, 44],
+    ]);
+  });
+
+  it(`Returns separate entries separately`, () => {
+    const map = new MultiRecordMap();
+    map.set(o1a, 22);
+    map.set(o1b, 33);
+    map.set(o1c, 44);
+    map.set(o2, 55);
+    expect([...map.entries()]).toEqual([
+      [o1a, 44],
+      [o2, 55],
+    ]);
+  });
+
+});

--- a/src/tests/multi-id-map.test.ts
+++ b/src/tests/multi-id-map.test.ts
@@ -52,4 +52,25 @@ describe(`Multi-ID Map`, () => {
     ]);
   });
 
+  it(`Can get individual entries`, () => {
+    const map = new MultiRecordMap();
+    map.set(o1a, 22);
+    map.set(o1b, 33);
+    map.set(o1c, 44);
+    map.set(o2, 55);
+    expect(map.get(o1a)).toBe(44);
+    expect(map.get(o1b)).toBe(44);
+    expect(map.get(o1c)).toBe(44);
+    expect(map.get(o2)).toBe(55);
+  });
+
+  it(`Returns undefined for keys with absent id-keys`, () => {
+    const map = new MultiRecordMap();
+    map.set(o1a, 22);
+    expect(map.get(o1a)).toBe(22);
+    expect(map.get(o1b)).toBe(22);
+    expect(map.get(o1c)).toBe(undefined);
+    expect(map.get(o2)).toBe(undefined);
+  });
+
 });


### PR DESCRIPTION
This closes subtask #82 and finishes out #59.

When it runs:

- Data shift analyzation runs directly after each loop in Docker
- Local dev can run it manually as an NPM task

How it reports:

- If Slack is configured via ENV, sends message to Slack error channel
- Always prints to standard out and standard error

Configuration it runs with:

- Can set ENV variable for late-transaction threshold
- Defaults to 30 days (ignores transactions that appear 29 days later)

What it does:

- Checks for missing transactions
- Checks for missing licenses
- Checks for transactions that appear later than claimed
- Checks for altered transactions
- Checks for altered licenses

Altered license fields checked:
- `addonKey`
- `addonName`
- `hosting`
- `maintenanceStartDate`

Altered transaction fields checked:
- `saleDate`
- `saleType`
- `addonKey`
- `addonName`
- `hosting`
- `country`
- `region`
- `purchasePrice`
- `vendorAmount`
- `billingPeriod`
- `maintenanceStartDate`
- `maintenanceEndDate`

Configuration steps required:

1. Add persistent volume to Docker
2. Increase Node.js memory as needed via `--max-old-space-size`
