### PR TITLE
Can specify managed HubSpot fields via ENV variables.

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -58,6 +58,7 @@ HUBSPOT_CONTACT_RELATED_PRODUCTS_ATTR=related_products
 HUBSPOT_CONTACT_LAST_ASSOCIATED_PARTNER=last_associated_partner
 
 # Optional comma-separated field names to be managed
+# See "Managed Fields" in docs/HUBSPOT.md file
 HUBSPOT_MANAGED_DEAL_FIELDS=country
 HUBSPOT_MANAGED_CONTACT_FIELDS=firstname,lastname
 

--- a/.sample.env
+++ b/.sample.env
@@ -57,6 +57,10 @@ HUBSPOT_CONTACT_REGION_ATTR=region
 HUBSPOT_CONTACT_RELATED_PRODUCTS_ATTR=related_products
 HUBSPOT_CONTACT_LAST_ASSOCIATED_PARTNER=last_associated_partner
 
+# Optional comma-separated field names to be managed
+HUBSPOT_MANAGED_DEAL_FIELDS=country
+HUBSPOT_MANAGED_CONTACT_FIELDS=firstname,lastname
+
 # Mapping of your addonKeys to the platform
 ADDONKEY_PLATFORMS=my-conf-app=Confluence,com.my.jira.app=Jira
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ See [Analize Data Shift](./docs/ANALIZE_DATA_SHIFT.md) docs for this sub-functio
 
 ## Changelog
 
+### 0.4.1
+
+- Added Managed Fields; see [HUBSPOT.md](./docs/HUBSPOT.md) for details
+
 ### 0.4.0
 
 - Added `KEEP_DATA_SETS` ENV variable.

--- a/docs/HUBSPOT.md
+++ b/docs/HUBSPOT.md
@@ -1,4 +1,6 @@
-## HubSpot Setup
+# HubSpot Setup
+
+## Required Fields
 
 Add any of these fields in HubSpot, and assign their internal IDs to an ENV var:
 
@@ -32,3 +34,18 @@ Add any of these fields in HubSpot, and assign their internal IDs to an ENV var:
 | TransactionId        | 1-line Text | (for engine use)           | `HUBSPOT_DEAL_TRANSACTIONID_ATTR`        | ✔️        |
 | AppEntitlementId     | 1-line Text | (for engine use)           | `HUBSPOT_DEAL_APPENTITLEMENTID_ATTR`     | ✔️        |
 | AppEntitlementNumber | 1-line Text | (for engine use)           | `HUBSPOT_DEAL_APPENTITLEMENTNUMBER_ATTR` | ✔️        |
+
+## Managed Fields
+
+Managed fields are HubSpot fields that the Marketing Automation Engine may only update if the field is currently empty.
+
+The purpose of managed fields is to allow manual data cleanup/sanitation, after the engine creates HubSpot entities.
+
+For example, if Contact.FirstName is managed:
+
+* When creating a contact, first name will be set
+* When updating a contact:
+  * If first name is blank, first name will be set
+  * If first name is already set, first name will not be updated
+
+See the sample .env file for how to set managed fields via ENV variables.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marketing-automation-engine",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "marketing-automation-engine",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "ISC",
       "dependencies": {
         "@hubspot/api-client": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marketing-automation-engine",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "",
   "main": "out/bin/main.js",
   "scripts": {

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -78,6 +78,7 @@ export function hubspotDealConfigFromENV(): HubspotDealConfig {
       associatedPartner: optional('HUBSPOT_DEAL_ASSOCIATED_PARTNER'),
       duplicateOf: optional('HUBSPOT_DEAL_DUPLICATEOF_ATTR'),
     },
+    managedFields: new Set(optional('HUBSPOT_MANAGED_DEAL_FIELDS')?.split(/\s*,\s*/g) ?? []),
   };
 }
 
@@ -95,6 +96,7 @@ export function hubspotContactConfigFromENV(): HubspotContactConfig {
       relatedProducts: optional('HUBSPOT_CONTACT_RELATED_PRODUCTS_ATTR'),
       lastAssociatedPartner: optional('HUBSPOT_CONTACT_LAST_ASSOCIATED_PARTNER'),
     },
+    managedFields: new Set(optional('HUBSPOT_MANAGED_CONTACT_FIELDS')?.split(/\s*,\s*/g) ?? []),
   };
 }
 

--- a/src/lib/hubspot/entity.ts
+++ b/src/lib/hubspot/entity.ts
@@ -34,12 +34,20 @@ export abstract class Entity<D extends Record<string, any>> {
       set: (_target, _key, _val) => {
         const key = _key as K;
         const val = _val as D[K];
-        this.indexer.removeIndexesFor(key, this);
-        this.newData[key] = val;
-        this.indexer.addIndexesFor(key, val, this);
+        if (!this._oldData[key] || !this.#isFieldManaged(key as string)) {
+          this.indexer.removeIndexesFor(key, this);
+          this.newData[key] = val;
+          this.indexer.addIndexesFor(key, val, this);
+        }
         return true;
       },
     });
+  }
+
+  #isFieldManaged(key: string): boolean {
+    const hsFieldName = this.adapter.data[key].property;
+    if (!hsFieldName) return false;
+    return this.adapter.managedFields.has(hsFieldName);
   }
 
   get kind() {

--- a/src/lib/hubspot/interfaces.ts
+++ b/src/lib/hubspot/interfaces.ts
@@ -47,4 +47,6 @@ export interface EntityAdapter<D> {
 
   additionalProperties: string[],
 
+  managedFields: Set<string>,
+
 }

--- a/src/lib/model/company.ts
+++ b/src/lib/model/company.ts
@@ -37,6 +37,8 @@ export const CompanyAdapter: EntityAdapter<CompanyData> = {
 
   additionalProperties: [],
 
+  managedFields: new Set(),
+
 };
 
 export class CompanyManager extends EntityManager<CompanyData, Company> {

--- a/src/lib/model/contact.ts
+++ b/src/lib/model/contact.ts
@@ -60,6 +60,7 @@ export interface HubspotContactConfig {
     relatedProducts?: string,
     lastAssociatedPartner?: string,
   },
+  managedFields?: Set<string>,
 }
 
 function makeAdapter(config: HubspotContactConfig): EntityAdapter<ContactData> {
@@ -155,6 +156,8 @@ function makeAdapter(config: HubspotContactConfig): EntityAdapter<ContactData> {
     },
 
     additionalProperties: ['hs_additional_emails'],
+
+    managedFields: config.managedFields ?? new Set(),
 
   };
 }

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -102,6 +102,7 @@ export interface HubspotDealConfig {
     associatedPartner?: string,
     duplicateOf?: string,
   },
+  managedFields?: Set<string>,
 }
 
 export interface HubspotRequiredDealConfig {
@@ -283,6 +284,8 @@ function makeAdapter(config: HubspotDealConfig): EntityAdapter<DealData> {
       'hs_sales_email_last_replied',
       'createdate',
     ],
+
+    managedFields: config.managedFields ?? new Set(),
 
   };
 


### PR DESCRIPTION
Closes #64 

---

Given this sample configuration:

```env
HUBSPOT_MANAGED_DEAL_FIELDS=country
HUBSPOT_MANAGED_CONTACT_FIELDS=firstname,lastname
```

Then when we try to create or update a contact:

* If contact's "firstname" was empty before, or contact is being created by MAE
  * It will be set/updated according to normal engine logic
* Otherwise if it's non-blank:
  * Any updates to this field will be skipped in the engine
