### PR TITLE
Fix data shift reports

### DIFF
--- a/src/lib/data-shift/reporter.ts
+++ b/src/lib/data-shift/reporter.ts
@@ -35,12 +35,12 @@ export class DataShiftReporter {
 
     this.#reportResult('Deleted Licenses', results.deletedLicenses, [
       [{ title: 'License' }, row => row.id],
-      [{ title: 'Timestamp' }, row => row.timestampChecked],
+      [{ title: 'Timestamp' }, row => row.timestampNotFound],
     ]);
 
     this.#reportResult('Deleted Transactions', results.deletedTransactions, [
       [{ title: 'Transaction' }, row => row.id],
-      [{ title: 'Timestamp' }, row => row.timestampChecked],
+      [{ title: 'Timestamp' }, row => row.timestampNotFound],
     ]);
 
     this.#reportResult('Late Transactions', results.lateTransactions, [

--- a/src/lib/data-shift/reporter.ts
+++ b/src/lib/data-shift/reporter.ts
@@ -20,31 +20,33 @@ export class DataShiftReporter {
   }) {
 
     this.#reportResult('Altered Licenses', results.alteredLicenses, [
-      [{ title: 'License' }, row => row.id],
+      [{ title: 'License ID' }, row => row.id],
       [{ title: 'Field' }, row => row.key],
       [{ title: 'Value' }, row => row.val],
       [{ title: 'Last Value' }, row => row.lastVal],
     ]);
 
     this.#reportResult('Altered Transactions', results.alteredTransactions, [
-      [{ title: 'Transaction' }, row => row.id],
+      [{ title: 'Transaction Unique ID' }, row => row.id],
       [{ title: 'Field' }, row => row.key],
       [{ title: 'Value' }, row => row.val],
       [{ title: 'Last Value' }, row => row.lastVal],
     ]);
 
     this.#reportResult('Deleted Licenses', results.deletedLicenses, [
-      [{ title: 'License' }, row => row.id],
-      [{ title: 'Timestamp' }, row => row.timestampNotFound],
+      [{ title: 'License ID' }, row => row.id],
+      [{ title: 'When Last Seen' }, row => row.timestampLastSeen],
+      [{ title: 'When Not Found' }, row => row.timestampNotFound],
     ]);
 
     this.#reportResult('Deleted Transactions', results.deletedTransactions, [
-      [{ title: 'Transaction' }, row => row.id],
-      [{ title: 'Timestamp' }, row => row.timestampNotFound],
+      [{ title: 'Transaction Unique ID' }, row => row.id],
+      [{ title: 'When Last Seen' }, row => row.timestampLastSeen],
+      [{ title: 'When Not Found' }, row => row.timestampNotFound],
     ]);
 
     this.#reportResult('Late Transactions', results.lateTransactions, [
-      [{ title: 'Transaction' }, row => row.id],
+      [{ title: 'Transaction Unique ID' }, row => row.id],
       [{ title: 'Date Expected' }, row => row.expected],
       [{ title: 'Date Found' }, row => row.found],
     ]);

--- a/src/lib/model/license.ts
+++ b/src/lib/model/license.ts
@@ -133,13 +133,13 @@ export class License extends MpacRecord<LicenseData> {
   public constructor(data: LicenseData) {
     super(data);
 
-    const maybeAdd = (id: string | null) => {
-      if (id) this.ids.push(id);
+    const maybeAdd = (prefix: string, id: string | null) => {
+      if (id) this.ids.push(`${prefix}-${id}`);
     };
 
-    maybeAdd(this.data.addonLicenseId);
-    maybeAdd(this.data.appEntitlementId);
-    maybeAdd(this.data.appEntitlementNumber);
+    maybeAdd('ALI', this.data.addonLicenseId);
+    maybeAdd('AEI', this.data.appEntitlementId);
+    maybeAdd('AEN', this.data.appEntitlementNumber);
 
     this.id = this.ids.find(id => id)!;
 

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -86,13 +86,13 @@ export class Transaction extends MpacRecord<TransactionData> {
   public constructor(data: TransactionData) {
     super(data);
 
-    const maybeAdd = (id: string | null) => {
-      if (id) this.ids.push(uniqueTransactionId(this.data.transactionId, id));
+    const maybeAdd = (prefix: string, id: string | null) => {
+      if (id) this.ids.push(uniqueTransactionId(this.data.transactionId, `${prefix}-${id}`));
     };
 
-    maybeAdd(this.data.addonLicenseId);
-    maybeAdd(this.data.appEntitlementId);
-    maybeAdd(this.data.appEntitlementNumber);
+    maybeAdd('ALI', this.data.addonLicenseId);
+    maybeAdd('AEI', this.data.appEntitlementId);
+    maybeAdd('AEN', this.data.appEntitlementNumber);
 
     this.id = this.ids.find(id => id)!;
 
@@ -118,5 +118,6 @@ export class Transaction extends MpacRecord<TransactionData> {
 }
 
 export function uniqueTransactionId(transactionId: string, licenseId: string) {
+  if (!transactionId.startsWith('AT')) transactionId = `(AT)${transactionId}`;
   return `${transactionId}[${licenseId}]`
 }


### PR DESCRIPTION
Fixes #91 

* Transaction IDs not prefixed with AT (e.g. refunds) have `(AT)` prefixed for clarity
* License IDs have ALI, AEI, or AEN prefixed to them
* "Timestamp" column has been renamed to "When Not Found"
* Column "When Last Seen" has been added
* About 30 calories were spent on this PR according to [Harvard Health Publications](https://www.health.harvard.edu/blog/the-truth-behind-standing-desks-2016092310264)
* That number [was probably increased](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5435671/) with assistance from Royal Deluxe

Examples:

```
Deleted Transactions                                                                          
  Transaction Unique ID          When Last Seen                  When Not Found               
  ---------------------          --------------                  --------------               
  (AT)119265[ALI-12447570]       2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  (AT)120117[ALI-10339246]       2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  (AT)120510[ALI-12399236]       2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  (AT)3286132735[ALI-10949785]   2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  (AT)6345447738[ALI-11066026]   2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  (AT)6491993784[ALI-13979381]   2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  AT-100007289[ALI-16739086]     2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  AT-100009658[ALI-12358478]     2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  AT-100489442[ALI-13680304]     2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  AT-100489442[ALI-8884175]      2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00

Deleted Licenses                                                               
  License ID      When Last Seen                  When Not Found               
  ----------      --------------                  --------------               
  ALI-10005196    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  ALI-10005730    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  ALI-10015219    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  ALI-10031038    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  ALI-10032900    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  ALI-10036865    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  ALI-10046409    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  ALI-10052310    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  ALI-10052764    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
  ALI-10068583    2022-04-01T12:03:18.554-05:00   2022-04-09T14:39:54.282-05:00
```
