### PR TITLE
Fixes entity-linking bug

### DIFF
--- a/src/lib/hubspot/manager.ts
+++ b/src/lib/hubspot/manager.ts
@@ -56,8 +56,10 @@ export abstract class EntityManager<
         const me = this.get(meId);
         if (!me) throw new Error(`Couldn't find kind=${this.kind} id=${meId}`);
 
-        const [toKind, youId] = rawAssoc.split(':') as [EntityKind, string];
-        const you = managers[`${toKind}Manager`].get(youId);
+        const [toKind, youId] = rawAssoc.split(':') as [string, string];
+        const FIX_TOKIND_REGEX = /_unlabeled$/;
+        const normalizedToKind = (toKind.match(FIX_TOKIND_REGEX) ? toKind.replace(FIX_TOKIND_REGEX, '') : toKind) as EntityKind;
+        const you = managers[`${normalizedToKind}Manager`].get(youId);
         if (!you) throw new Error(`Couldn't find kind=${toKind} id=${youId}`);
 
         me.addAssociation(you, { firstSide: true, initial: true });


### PR DESCRIPTION
This apparently happens because sometimes an entity kind can be "company_unlabeled" instead of just "company". Not sure why. Quick fix here is to just remove "_unlabeled" from it, which gets the engine working again. Longer term, we need to know what this type is and why HubSpot is giving it to us sometimes. Googled it and found nothing.