### PR TITLE
Fix MPAC input validation for empty partner data

### DIFF
--- a/src/lib/marketplace/validation.ts
+++ b/src/lib/marketplace/validation.ts
@@ -97,7 +97,7 @@ export function assertRequiredTransactionFields(transaction: Transaction) {
   validateField(transaction, transaction => transaction.data.maintenanceEndDate);
 }
 
-function validateField<T>(o: T, accessor: (o: T) => any, validator: (o: T) => boolean = o => !!o) {
+function validateField<T, V>(o: T, accessor: (o: T) => V, validator: (o: V) => boolean = o => !!o) {
   const val = accessor(o);
   const path = accessor.toString().replace(/^(\w+) => /, '');
   if (!validator(val)) throw new AttachableError(`Missing field: ${path} (found ${JSON.stringify(val)})`, JSON.stringify(o, null, 2));

--- a/src/lib/marketplace/validation.ts
+++ b/src/lib/marketplace/validation.ts
@@ -72,6 +72,7 @@ export function assertRequiredLicenseFields(license: License) {
   validateField(license, license => license.data.maintenanceStartDate);
   validateField(license, license => license.data.maintenanceEndDate);
   validateField(license, license => license.data.status);
+  validateField(license, license => license.data.partnerDetails?.billingContact, o => !o || typeof o.email === 'string');
 }
 
 export function assertRequiredTransactionFields(transaction: Transaction) {
@@ -95,6 +96,7 @@ export function assertRequiredTransactionFields(transaction: Transaction) {
   validateField(transaction, transaction => transaction.data.saleType);
   validateField(transaction, transaction => transaction.data.maintenanceStartDate);
   validateField(transaction, transaction => transaction.data.maintenanceEndDate);
+  validateField(transaction, transaction => transaction.data.partnerDetails?.billingContact, o => !o || typeof o.email === 'string');
 }
 
 function validateField<T, V>(o: T, accessor: (o: T) => V, validator: (o: V) => boolean = o => !!o) {


### PR DESCRIPTION
Resolves #105 by reporting an error when MPAC returns empty data for partner contact details