### PR TITLE
Make Contact Deployment field multiselect

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,9 @@
         "<node_internals>/**"
       ],
       "program": "${workspaceFolder}/src/bin/run-once.ts",
+      "args": [
+        "fast"
+      ],
       "type": "pwa-node"
     },
     {

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See [Analize Data Shift](./docs/ANALIZE_DATA_SHIFT.md) docs for this sub-functio
 ### Unreleased
 
 - Changed Contact 'Deployment' field; see field in [HUBSPOT.md](./docs/HUBSPOT.md) for details
+- Fixed bug that might have prevented some multi-select fields from updating
 
 ### 0.4.1
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ See [Analize Data Shift](./docs/ANALIZE_DATA_SHIFT.md) docs for this sub-functio
 
 ## Changelog
 
+### Unreleased
+
+- Changed Contact 'Deployment' field; see field in [HUBSPOT.md](./docs/HUBSPOT.md) for details
+
 ### 0.4.1
 
 - Added Managed Fields; see [HUBSPOT.md](./docs/HUBSPOT.md) for details

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -170,7 +170,7 @@ Then, for each contact in each group, we set these fields, if configured via Hub
 - License Tier is set to the highest one found in their group
 - Last MPAC Event is set to the latest one found in their group
 - Related Products has the app key added
-- Deployment is set to app hosting, or "Multiple" if different from contact's current hosting
+- Deployment set has app hosting added to it
 
 ### Generating deals based on matches
 

--- a/docs/HUBSPOT.md
+++ b/docs/HUBSPOT.md
@@ -6,16 +6,16 @@ Add any of these fields in HubSpot, and assign their internal IDs to an ENV var:
 
 ### Contacts
 
-| Field                   | Type        | Allowed Values                           | ENV var                                   | Required |
-| ----------------------- | ----------- | ---------------------------------------- | ----------------------------------------- | -------- |
-| License Tier            | Number      | *                                        | `HUBSPOT_CONTACT_LICENSE_TIER_ATTR`       | ❌        |
-| Last MPAC Event         | Date        | *                                        | `HUBSPOT_CONTACT_LAST_MPAC_EVENT_ATTR`    | ❌        |
-| Contact Type            | 1-Select    | 'Partner' or 'Customer'                  | `HUBSPOT_CONTACT_CONTACT_TYPE_ATTR`       | ❌        |
-| Region                  | 1-Select    | "region" of MPAC records                 | `HUBSPOT_CONTACT_REGION_ATTR`             | ❌        |
-| Related Products        | N-Select    | `ADDONKEY_PLATFORMS` rhs vals            | `HUBSPOT_CONTACT_RELATED_PRODUCTS_ATTR`   | ❌        |
-| Products                | N-Select    | "addonKey" of MPAC records               | `HUBSPOT_CONTACT_PRODUCTS_ATTR`           | ❌        |
-| Deployment              | 1-Select    | "hosting" of MPAC records, or 'Multiple' | `HUBSPOT_CONTACT_DEPLOYMENT_ATTR`         | ❌        |
-| Last Associated Partner | 1-line Text | Valid domains                            | `HUBSPOT_CONTACT_LAST_ASSOCIATED_PARTNER` | ❌        |
+| Field                   | Type        | Allowed Values                | ENV var                                   | Required |
+| ----------------------- | ----------- | ----------------------------- | ----------------------------------------- | -------- |
+| License Tier            | Number      | *                             | `HUBSPOT_CONTACT_LICENSE_TIER_ATTR`       | ❌        |
+| Last MPAC Event         | Date        | *                             | `HUBSPOT_CONTACT_LAST_MPAC_EVENT_ATTR`    | ❌        |
+| Contact Type            | 1-Select    | 'Partner' or 'Customer'       | `HUBSPOT_CONTACT_CONTACT_TYPE_ATTR`       | ❌        |
+| Region                  | 1-Select    | "region" of MPAC records      | `HUBSPOT_CONTACT_REGION_ATTR`             | ❌        |
+| Related Products        | N-Select    | `ADDONKEY_PLATFORMS` rhs vals | `HUBSPOT_CONTACT_RELATED_PRODUCTS_ATTR`   | ❌        |
+| Products                | N-Select    | "addonKey" of MPAC records    | `HUBSPOT_CONTACT_PRODUCTS_ATTR`           | ❌        |
+| Deployment              | N-Select    | "hosting" of MPAC records     | `HUBSPOT_CONTACT_DEPLOYMENT_ATTR`         | ❌        |
+| Last Associated Partner | 1-line Text | Valid domains                 | `HUBSPOT_CONTACT_LAST_ASSOCIATED_PARTNER` | ❌        |
 
 
 ### Deals

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "marketing-automation-engine",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "marketing-automation-engine",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "ISC",
       "dependencies": {
         "@hubspot/api-client": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marketing-automation-engine",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "",
   "main": "out/bin/main.js",
   "scripts": {

--- a/src/lib/contact-generator/contact-generator.ts
+++ b/src/lib/contact-generator/contact-generator.ts
@@ -105,7 +105,7 @@ export class ContactGenerator {
       country: capitalize.words(item.data.country),
       region: item.data.region,
       relatedProducts: new Set(),
-      deployment: item.data.hosting,
+      deployment: new Set([item.data.hosting]),
       products: new Set([item.data.addonKey].filter(key => notIgnored(this.archivedApps, key))),
       licenseTier: null,
       lastMpacEvent: '',
@@ -166,6 +166,9 @@ export function mergeContactInfo(contact: ContactData, contacts: GeneratedContac
   for (const other of contacts) {
     for (const product of other.products) {
       contact.products.add(product);
+    }
+    for (const deployment of other.deployment) {
+      contact.deployment.add(deployment);
     }
   }
 }

--- a/src/lib/contact-generator/update-contacts.ts
+++ b/src/lib/contact-generator/update-contacts.ts
@@ -41,12 +41,7 @@ export function updateContactsBasedOnMatchResults(engine: Engine, allMatches: Re
       }
 
       const hosting = license[0].data.hosting;
-      if (!contact.data.deployment) {
-        contact.data.deployment = hosting;
-      }
-      else if (contact.data.deployment !== hosting) {
-        contact.data.deployment = 'Multiple';
-      }
+      contact.data.deployment.add(hosting);
     }
   }
 

--- a/src/lib/contact-generator/update-contacts.ts
+++ b/src/lib/contact-generator/update-contacts.ts
@@ -56,6 +56,10 @@ export function updateContactsBasedOnMatchResults(engine: Engine, allMatches: Re
   for (const contact of engine.hubspot.contactManager.getAll()) {
     const lastRecord = contact.records[0];
     contact.data.lastAssociatedPartner = lastRecord?.partnerDomain ?? null;
+
+    // This is needed when migrating from old Deployment schema to new one
+    contact.data.deployment = new Set(contact.data.deployment);
+    contact.data.deployment.delete('Multiple' as any);
   }
 }
 

--- a/src/lib/contact-generator/update-contacts.ts
+++ b/src/lib/contact-generator/update-contacts.ts
@@ -59,7 +59,7 @@ export function updateContactsBasedOnMatchResults(engine: Engine, allMatches: Re
 
     // This is needed when migrating from old Deployment schema to new one
     contact.data.deployment = new Set(contact.data.deployment);
-    contact.data.deployment.delete('Multiple' as any);
+    contact.data.deployment.delete('Multiple');
   }
 }
 

--- a/src/lib/hubspot/entity.ts
+++ b/src/lib/hubspot/entity.ts
@@ -68,8 +68,13 @@ export abstract class Entity<D extends Record<string, any>> {
   public getPropertyChanges() {
     const upProperties: Partial<{ [K in keyof D]: string }> = Object.create(null);
     for (const [k, v] of Object.entries(this.newData)) {
-      if (v !== this._oldData[k]) {
-        const spec = this.adapter.data[k];
+      const spec = this.adapter.data[k];
+      const v2 = this._oldData[k];
+      if (
+        (spec.makeComparable?.(v) ?? v)
+        !==
+        (spec.makeComparable?.(v2) ?? v2)
+      ) {
         if (spec.property) {
           const upKey = spec.property as keyof D;
           const upVal = spec.up(v);

--- a/src/lib/hubspot/interfaces.ts
+++ b/src/lib/hubspot/interfaces.ts
@@ -42,6 +42,7 @@ export interface EntityAdapter<D> {
     property: string | undefined,
     down: (data: string | null) => D[K],
     up: (data: D[K]) => string,
+    makeComparable?: (v: D[K]) => string,
     identifier?: true,
   } };
 

--- a/src/lib/model/contact.ts
+++ b/src/lib/model/contact.ts
@@ -127,6 +127,7 @@ function makeAdapter(config: HubspotContactConfig): EntityAdapter<ContactData> {
         property: config.attrs?.relatedProducts,
         down: related_products => new Set(related_products ? related_products.split(';') : []),
         up: relatedProducts => [...relatedProducts].join(';'),
+        makeComparable: setToComparableString,
       },
       licenseTier: {
         property: config.attrs?.licenseTier,
@@ -139,11 +140,13 @@ function makeAdapter(config: HubspotContactConfig): EntityAdapter<ContactData> {
           ? new Set()
           : new Set(deployment.split(';')) as ContactData['deployment'],
         up: deployment => [...deployment].join(';'),
+        makeComparable: setToComparableString,
       },
       products: {
         property: config.attrs?.products,
         down: products => new Set(products?.split(';') || []),
         up: products => [...products].join(';'),
+        makeComparable: setToComparableString,
       },
       lastMpacEvent: {
         property: config.attrs?.lastMpacEvent,
@@ -181,4 +184,8 @@ export class ContactManager extends EntityManager<ContactData, Contact> {
 
 export function domainFor(email: string): string {
   return email.split('@')[1];
+}
+
+function setToComparableString(a: Set<string>) {
+  return [...a].sort().join();
 }

--- a/src/lib/model/contact.ts
+++ b/src/lib/model/contact.ts
@@ -136,9 +136,7 @@ function makeAdapter(config: HubspotContactConfig): EntityAdapter<ContactData> {
       },
       deployment: {
         property: config.attrs?.deployment,
-        down: deployment => deployment === 'Multiple' || !deployment
-          ? new Set()
-          : new Set(deployment.split(';')) as ContactData['deployment'],
+        down: deployment => new Set(deployment?.split(';') ?? []) as ContactData['deployment'],
         up: deployment => [...deployment].join(';'),
         makeComparable: setToComparableString,
       },

--- a/src/lib/model/contact.ts
+++ b/src/lib/model/contact.ts
@@ -21,7 +21,7 @@ export type ContactData = {
   region: string | null;
 
   products: Set<string>;
-  deployment: 'Cloud' | 'Data Center' | 'Server' | 'Multiple' | null;
+  deployment: Set<'Cloud' | 'Data Center' | 'Server'>;
 
   relatedProducts: Set<string>;
   licenseTier: number | null;
@@ -135,8 +135,10 @@ function makeAdapter(config: HubspotContactConfig): EntityAdapter<ContactData> {
       },
       deployment: {
         property: config.attrs?.deployment,
-        down: deployment => deployment as ContactData['deployment'] ?? null,
-        up: deployment => deployment ?? '',
+        down: deployment => deployment === 'Multiple' || !deployment
+          ? new Set()
+          : new Set(deployment.split(';')) as ContactData['deployment'],
+        up: deployment => [...deployment].join(';'),
       },
       products: {
         property: config.attrs?.products,

--- a/src/lib/model/contact.ts
+++ b/src/lib/model/contact.ts
@@ -21,7 +21,7 @@ export type ContactData = {
   region: string | null;
 
   products: Set<string>;
-  deployment: Set<'Cloud' | 'Data Center' | 'Server'>;
+  deployment: Set<string>;
 
   relatedProducts: Set<string>;
   licenseTier: number | null;
@@ -136,7 +136,7 @@ function makeAdapter(config: HubspotContactConfig): EntityAdapter<ContactData> {
       },
       deployment: {
         property: config.attrs?.deployment,
-        down: deployment => new Set(deployment?.split(';') ?? []) as ContactData['deployment'],
+        down: deployment => new Set(deployment?.split(';') ?? []),
         up: deployment => [...deployment].join(';'),
         makeComparable: setToComparableString,
       },

--- a/src/tests/generate-contacts.test.ts
+++ b/src/tests/generate-contacts.test.ts
@@ -7,7 +7,6 @@ describe('updating latest contact properties', () => {
       lastUpdated: '2021-04-02',
       country: 'country2',
       region: 'region2',
-      deployment: 'Cloud',
       email: 'email2',
     });
 
@@ -30,7 +29,7 @@ describe('updating latest contact properties', () => {
       lastUpdated: '2021-04-02',
       country: 'country2',
       region: 'region2',
-      deployment: 'Cloud',
+      deployment: new Set(['Server']),
       email: 'email2',
       firstName: 'firstName',
       lastName: 'lastName',
@@ -190,6 +189,17 @@ describe('updating latest contact properties', () => {
     expect(a).toEqual(fakeContact({ products: new Set(['p1', 'p2', 'p3']) }));
   });
 
+  it('merges deployments', () => {
+    const a = fakeContact({ deployment: new Set(['Server']) });
+
+    mergeContactInfo(a, [
+      fakeContact({ deployment: new Set(['Cloud']) }),
+      a,
+    ]);
+
+    expect(a).toEqual(fakeContact({ deployment: new Set(['Cloud', 'Server']) }));
+  });
+
 });
 
 function fakeContact(props: Partial<GeneratedContact>): GeneratedContact {
@@ -199,7 +209,7 @@ function fakeContact(props: Partial<GeneratedContact>): GeneratedContact {
     contactType: 'Customer',
     country: 'country1',
     region: 'region1',
-    deployment: 'Server',
+    deployment: new Set(['Server']),
     firstName: null,
     lastName: null,
     phone: null,


### PR DESCRIPTION
For #123 

- [x] Changes Contact Deployment to multi-select checkboxes matching MPAC 'hosting' values
- [x] Fixes bug that might have prevented some multi-select fields from updating in CRM
- [x] Updates HubSpot/engine docs and changelog, and bumps version in NPM and readme