### PR TITLE
Better fix for set comparison bug recently introduced

### DIFF
--- a/src/lib/hubspot/entity.ts
+++ b/src/lib/hubspot/entity.ts
@@ -69,12 +69,12 @@ export abstract class Entity<D extends Record<string, any>> {
     const upProperties: Partial<{ [K in keyof D]: string }> = Object.create(null);
     for (const [k, v] of Object.entries(this.newData)) {
       const spec = this.adapter.data[k];
-      const v2 = this._oldData[k];
-      if (
-        (spec.makeComparable?.(v) ?? v)
-        !==
-        (spec.makeComparable?.(v2) ?? v2)
-      ) {
+      const oldValue = this._oldData[k];
+
+      const compString1 = oldValue === undefined ? '' : (spec.makeComparable?.(oldValue) ?? oldValue);
+      const compString2 = spec.makeComparable?.(v) ?? v;
+
+      if (compString1 !== compString2) {
         if (spec.property) {
           const upKey = spec.property as keyof D;
           const upVal = spec.up(v);

--- a/src/lib/model/contact.ts
+++ b/src/lib/model/contact.ts
@@ -184,6 +184,6 @@ export function domainFor(email: string): string {
   return email.split('@')[1];
 }
 
-function setToComparableString(a: Set<string> | undefined) {
-  return a ? [...a].sort().join() : '';
+function setToComparableString(a: Set<string>) {
+  return [...a].sort().join();
 }


### PR DESCRIPTION
The value is undefined because it's a created entity, and in src/lib/hubspot/manager.ts:71 it gives an empty object as its old-data param. In this case, all fields will be undefined for the old value. Rather than checking each of them, we can just check the value on the line in this PR and use the blank string to mean no-value when comparing with the new value, which must be an empty string for blank values anyway.