### PR TITLE
Fix reduce bug in deal duplicates edge case.

### DIFF
--- a/src/lib/engine/summary.ts
+++ b/src/lib/engine/summary.ts
@@ -20,7 +20,7 @@ export function printSummary(engine: Engine) {
     const dupTotal = ([...engine.hubspot.dealManager.duplicates]
       .flatMap(([primary, dups]) => dups)
       .map((dup) => dup.data.amount ?? 0)
-      .reduce((a, b) => a + b));
+      .reduce((a, b) => a + b, 0));
 
     engine.console?.printWarning('Deal Generator', 'Total of duplicates:', formatMoney(dupTotal));
     engine.console?.printWarning('Deal Generator', 'Total duplicates:', engine.hubspot.dealManager.duplicates.size);


### PR DESCRIPTION
There’s a strange edge case where there’s duplicates added to the duplicates-mapping during the deal generation phase, but there’s no duplicates in the inner array(s). I have to investigate the root cause of this more, but I couldn’t reproduce it locally with old data, so this PR gets the engine past the crash in the meantime while I continue to investigate.