### PR TITLE
Check if eval license exists and merely warn if not

### DIFF
--- a/src/lib/marketplace/structure.ts
+++ b/src/lib/marketplace/structure.ts
@@ -107,8 +107,17 @@ class MpacStructurer {
           licensesByAppEntitlementId.get(license.data.newEvalData.evaluationLicense) ??
           licensesByAppEntitlementNumber.get(license.data.newEvalData.evaluationLicense)
         );
-        license.evaluatedFrom = evalLicense;
-        evalLicense!.evaluatedTo = license;
+
+        if (evalLicense) {
+          license.evaluatedFrom = evalLicense;
+          evalLicense.evaluatedTo = license;
+        }
+        else {
+          this.console?.printWarning('MPAC Verifier', `Cannot find evaluation license`, {
+            newEvalData: license.data.newEvalData,
+            onLicense: license.id,
+          });
+        }
       }
     }
 


### PR DESCRIPTION
This fixes a crash caused by a broken assumption that the `evaluationLicense` always points to a valid license. Either it's broken because Atlassian gave bad data, or because there's a bug somewhere in this app. This PR also logs enough info to help us figure out which one it is.

More detail: the JSON licenses MPAC gives us comes with `evaluationLicense` which is sometimes present in which case it should point to another license via some ID. When this code was written, it basically only pointed to `addonLicenseId` when present. This code was written so that if `evaluationLicense` was present, we would check for any license where it matches `addonLicenseId`, `appEntitlementId`, or `appEntitlementNumber`. There was an assertion in this code assuming a license was in fact found with one of these as the ID that `evaluationLicense` pointed to, and we went ahead and associated them in-memory for further processing. If this assertion was broken, it would cause an NPE and cause the run to fail. This PR fixes that by checking if the license was in fact found, and printing a warning to console if not, along with the ID of the license containing the `evaluationLicense` that couldn't be found, and its raw value of that field.