### PR TITLE
Better error messages for HubSpot Association API errors

### DIFF
--- a/src/lib/hubspot/api.ts
+++ b/src/lib/hubspot/api.ts
@@ -42,7 +42,7 @@ export default class HubspotAPI {
           .flatMap(([, { results }]) => (
             results.map(item => {
               const prefix = `${entityAdapter.kind}_to_`;
-              assert.ok(item.type.startsWith(prefix), `"${item.type}" does not start with "${prefix}"`);
+              assert.ok(item.type.startsWith(prefix), `"${item.type}" does not start with "${prefix}" for "${id}" to "${item.id}"`);
               const otherKind = item.type.substr(prefix.length) as EntityKind;
               return `${otherKind}:${item.id}` as RelativeAssociation;
             })

--- a/src/lib/hubspot/api.ts
+++ b/src/lib/hubspot/api.ts
@@ -42,7 +42,7 @@ export default class HubspotAPI {
           .flatMap(([, { results }]) => (
             results.map(item => {
               const prefix = `${entityAdapter.kind}_to_`;
-              assert.ok(item.type.startsWith(prefix));
+              assert.ok(item.type.startsWith(prefix), `"${item.type}" does not start with "${prefix}"`);
               const otherKind = item.type.substr(prefix.length) as EntityKind;
               return `${otherKind}:${item.id}` as RelativeAssociation;
             })
@@ -66,7 +66,7 @@ export default class HubspotAPI {
         throw new KnownError(`Hubspot v3 API for "${entityAdapter.kind}" had internal error.`);
       }
       else {
-        throw new Error(`Failed downloading ${entityAdapter.kind}s: ${JSON.stringify(body)}`);
+        throw new Error(`Failed downloading ${entityAdapter.kind}s.\n  Response body: ${JSON.stringify(body)}\n  Error stacktrace: ${e.stack}`);
       }
     }
   }


### PR DESCRIPTION
Before:

```
Error: Failed downloading companys: undefined
    at HubspotAPI.downloadHubspotEntities (C:\projects\marketing-automation\src\lib\hubspot\api.ts:69:15)
    at runNextTicks (node:internal/process/task_queues:60:5)
    at processTimers (node:internal/timers:504:9)
    at MultiDownloadLogger.wrap (C:\projects\marketing-automation\src\lib\log\download.ts:20:20)
    at async Promise.all (index 6)
    at downloadAllData (C:\projects\marketing-automation\src\lib\engine\download.ts:19:16)
```

After:

```
Error: Failed downloading companys.
  Response body: undefined
  Error stacktrace: AssertionError [ERR_ASSERTION]: "contractor" does not start with "company_to_" for "1234567890" to "987654321"
    at C:\projects\marketing-automation\src\lib\hubspot\api.ts:45:22
    at Array.map (<anonymous>)
    at C:\projects\marketing-automation\src\lib\hubspot\api.ts:43:21
    at Array.flatMap (<anonymous>)
    at C:\projects\marketing-automation\src\lib\hubspot\api.ts:42:12
    at Array.map (<anonymous>)
    at HubspotAPI.downloadHubspotEntities (C:\projects\marketing-automation\src\lib\hubspot\api.ts:38:43)
    at MultiDownloadLogger.wrap (C:\projects\marketing-automation\src\lib\log\download.ts:20:20)
    at async Promise.all (index 6)
    at downloadAllData (C:\projects\marketing-automation\src\lib\engine\download.ts:19:16)
    at HubspotAPI.downloadHubspotEntities (C:\projects\marketing-automation\src\lib\hubspot\api.ts:69:15)
    at MultiDownloadLogger.wrap (C:\projects\marketing-automation\src\lib\log\download.ts:20:20)
    at async Promise.all (index 6)
    at downloadAllData (C:\projects\marketing-automation\src\lib\engine\download.ts:19:16)
```