### PR TITLE
Fixes HubSpot custom association support.

### DIFF
--- a/src/bin/download.ts
+++ b/src/bin/download.ts
@@ -4,4 +4,4 @@ import { hubspotConfigFromENV } from '../lib/hubspot/hubspot';
 import { ConsoleLogger } from '../lib/log/console';
 
 const console = new ConsoleLogger();
-downloadAllData(console, hubspotConfigFromENV());
+void downloadAllData(console, hubspotConfigFromENV());

--- a/src/bin/download.ts
+++ b/src/bin/download.ts
@@ -1,8 +1,7 @@
 import 'source-map-support/register';
-import { hubspotSettingsFromENV } from '../lib/config/env';
 import { downloadAllData } from '../lib/engine/download';
 import { hubspotConfigFromENV } from '../lib/hubspot/hubspot';
 import { ConsoleLogger } from '../lib/log/console';
 
 const console = new ConsoleLogger();
-downloadAllData(console, hubspotConfigFromENV(), hubspotSettingsFromENV());
+downloadAllData(console, hubspotConfigFromENV());

--- a/src/bin/main.ts
+++ b/src/bin/main.ts
@@ -1,5 +1,5 @@
 import 'source-map-support/register';
-import { dataShiftConfigFromENV, engineConfigFromENV, hubspotSettingsFromENV, runLoopConfigFromENV } from "../lib/config/env";
+import { dataShiftConfigFromENV, engineConfigFromENV, runLoopConfigFromENV } from "../lib/config/env";
 import { DataShiftAnalyzer } from '../lib/data-shift/analyze';
 import { loadDataSets } from '../lib/data-shift/loader';
 import { DataShiftReporter } from '../lib/data-shift/reporter';
@@ -26,7 +26,7 @@ run(console, runLoopConfig, {
     dataManager.pruneDataSets(console);
 
     console.printInfo('Main', 'Downloading data');
-    const ms = await downloadAllData(console, hubspotConfigFromENV(), hubspotSettingsFromENV());
+    const ms = await downloadAllData(console, hubspotConfigFromENV());
     const dataSet = dataManager.dataSetFrom(ms);
     const logDir = dataSet.makeLogDir!('main');
 

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -1,7 +1,7 @@
 import dotenv from "dotenv";
 import { DataShiftConfig } from "../data-shift/analyze";
 import { EngineConfig } from "../engine/engine";
-import { HubspotCreds, HubspotSettings } from "../hubspot/api";
+import { HubspotCreds } from "../hubspot/api";
 import { MultiMpacCreds } from "../marketplace/api";
 import { MpacConfig } from "../marketplace/marketplace";
 import { HubspotContactConfig } from "../model/contact";
@@ -20,16 +20,14 @@ export function hubspotCredsFromENV(): HubspotCreds {
   };
 }
 
-export function hubspotSettingsFromENV(): HubspotSettings {
+export function hubspotSettingsFromENV() {
   const typeMappings = optional('HUBSPOT_ASSOCIATION_TYPE_MAPPINGS');
-  return {
-    typeMappings: (typeMappings
-      ? new Map(
-        typeMappings
-          .split(',')
-          .map(kv => kv.split(':') as [string, string]))
-      : undefined),
-  };
+  return (typeMappings
+    ? new Map(
+      typeMappings
+        .split(',')
+        .map(kv => kv.split(':') as [string, string]))
+    : undefined);
 }
 
 export function mpacCredsFromENV(): MultiMpacCreds {

--- a/src/lib/contact-generator/contact-generator.ts
+++ b/src/lib/contact-generator/contact-generator.ts
@@ -84,7 +84,8 @@ export class ContactGenerator {
   }
 
   private contactFrom(item: License | Transaction, info: ContactInfo | PartnerBillingInfo): GeneratedContact {
-    let [firstName, ...lastNameGroup] = (info.name || ' ').split(' ');
+    const [firstNameRaw, ...lastNameGroup] = (info.name || ' ').split(' ');
+    let firstName = firstNameRaw;
     let lastName = lastNameGroup.filter(n => n).join(' ');
 
     const NAME_URL_RE = /(.)\.([a-zA-Z]{2})/g;

--- a/src/lib/data-shift/reporter.ts
+++ b/src/lib/data-shift/reporter.ts
@@ -66,7 +66,7 @@ export class DataShiftReporter {
         rows: resultItems,
       });
 
-      this.slack?.notifyDataShiftIssues(resultLabel, Table.toString({
+      void this.slack?.notifyDataShiftIssues(resultLabel, Table.toString({
         cols: colSpecs,
         rows: resultItems,
       }));

--- a/src/lib/deal-generator/actions.ts
+++ b/src/lib/deal-generator/actions.ts
@@ -220,7 +220,7 @@ export class ActionGenerator {
   maybeMakeMetaAction(event: Exclude<DealRelevantEvent, RefundEvent>, deal: Deal | null, amount: number): Action | null {
     switch (event.meta) {
       case 'archived-app':
-      case 'mass-provider-only':
+      case 'mass-provider-only': {
         const reason = (event.meta === 'archived-app'
           ? 'Archived-app transaction'
           : 'Free-email-provider transaction'
@@ -229,6 +229,7 @@ export class ActionGenerator {
           this.ignore(reason, amount);
         }
         return { type: 'noop', deal, reason: event.meta };
+      }
       default:
         return null;
     }

--- a/src/lib/engine/download.ts
+++ b/src/lib/engine/download.ts
@@ -1,14 +1,14 @@
 import got from 'got';
 import promiseAllProperties from 'promise-all-properties';
 import { dataManager } from '../data/manager';
-import HubspotAPI, { HubspotSettings } from "../hubspot/api";
+import HubspotAPI from "../hubspot/api";
 import { Hubspot, HubspotConfig } from '../hubspot/hubspot';
 import { ConsoleLogger } from '../log/console';
 import { MultiDownloadLogger } from "../log/download";
 import { MarketplaceAPI } from "../marketplace/api";
 
-export async function downloadAllData(console: ConsoleLogger, hubspotConfig: HubspotConfig, hubspotSettings?: HubspotSettings) {
-  const hubspotAPI = new HubspotAPI(console, hubspotSettings);
+export async function downloadAllData(console: ConsoleLogger, hubspotConfig: HubspotConfig) {
+  const hubspotAPI = new HubspotAPI(console);
   const marketplaceAPI = new MarketplaceAPI();
 
   const hubspot = new Hubspot(hubspotConfig);

--- a/src/lib/engine/slack-notifier.ts
+++ b/src/lib/engine/slack-notifier.ts
@@ -26,7 +26,7 @@ export class SlackNotifier {
   ) { }
 
   public async notifyStarting() {
-    this.#postToSlack(`Starting Marketing Engine`);
+    void this.#postToSlack(`Starting Marketing Engine`);
   }
 
   public async notifyErrors(loopConfig: RunLoopConfig, errors: any[]) {

--- a/src/lib/hubspot/api.ts
+++ b/src/lib/hubspot/api.ts
@@ -28,7 +28,7 @@ export default class HubspotAPI {
       ...entityAdapter.additionalProperties,
     ];
 
-    let associations = ((inputAssociations.length > 0)
+    const associations = ((inputAssociations.length > 0)
       ? inputAssociations
       : undefined);
 

--- a/src/lib/hubspot/entity.ts
+++ b/src/lib/hubspot/entity.ts
@@ -138,7 +138,7 @@ export abstract class Entity<D extends Record<string, any>> {
       id: this.id!,
       properties: this.upsyncableData(),
       associations: [...this.upsyncableAssociations()].map(other => {
-        return `${other.kind}:${other.id}` as RelativeAssociation;
+        return `${this.kind}_to_${other.kind}:${other.id}` as RelativeAssociation;
       }),
     };
   }
@@ -148,9 +148,9 @@ export abstract class Entity<D extends Record<string, any>> {
     for (const [k, v] of Object.entries(this.newData)) {
       const spec = this.adapter.data[k];
       if (spec.property) {
-        const upKey = spec.property as keyof D;
+        const upKey = spec.property;
         const upVal = spec.up(v);
-        upProperties[upKey as string] = upVal;
+        upProperties[upKey] = upVal;
       }
     }
     return upProperties;

--- a/src/lib/hubspot/entity.ts
+++ b/src/lib/hubspot/entity.ts
@@ -1,6 +1,6 @@
 import { EntityAdapter, EntityKind, FullEntity, RelativeAssociation } from "./interfaces";
 
-export interface Indexer<D> {
+export interface Indexer<D extends Record<string, any>> {
   removeIndexesFor<K extends keyof D>(key: K, entity: Entity<D>): void;
   addIndexesFor<K extends keyof D>(key: K, val: D[K] | undefined, entity: Entity<D>): void;
 }

--- a/src/lib/hubspot/hubspot.ts
+++ b/src/lib/hubspot/hubspot.ts
@@ -1,4 +1,4 @@
-import { hubspotContactConfigFromENV, hubspotDealConfigFromENV } from "../config/env";
+import { hubspotContactConfigFromENV, hubspotDealConfigFromENV, hubspotSettingsFromENV } from "../config/env";
 import { RawDataSet } from "../data/raw";
 import { ConsoleLogger } from "../log/console";
 import { CompanyManager } from "../model/company";
@@ -9,6 +9,7 @@ import { Entity } from "./entity";
 export type HubspotConfig = {
   deal?: HubspotDealConfig;
   contact?: HubspotContactConfig;
+  typeMappings?: Map<string, string>,
 };
 
 export class Hubspot {
@@ -18,9 +19,11 @@ export class Hubspot {
   public companyManager;
 
   public constructor(config?: HubspotConfig) {
-    this.dealManager = new DealManager(config?.deal ?? {});
-    this.contactManager = new ContactManager(config?.contact ?? {});
-    this.companyManager = new CompanyManager();
+    const typeMappings = config?.typeMappings ?? new Map();
+
+    this.dealManager = new DealManager(typeMappings, config?.deal ?? {});
+    this.contactManager = new ContactManager(typeMappings, config?.contact ?? {});
+    this.companyManager = new CompanyManager(typeMappings);
   }
 
   public importData(data: RawDataSet, console?: ConsoleLogger) {
@@ -52,9 +55,10 @@ export class Hubspot {
 
 }
 
-export function hubspotConfigFromENV() {
+export function hubspotConfigFromENV(): HubspotConfig {
   return {
     contact: hubspotContactConfigFromENV(),
     deal: hubspotDealConfigFromENV(),
+    typeMappings: hubspotSettingsFromENV(),
   };
 }

--- a/src/lib/hubspot/interfaces.ts
+++ b/src/lib/hubspot/interfaces.ts
@@ -8,7 +8,7 @@ export type ResultEntity = {
   associations: RelativeAssociation[],
 };
 
-export type RelativeAssociation = `${EntityKind}:${string}`;
+export type RelativeAssociation = `${string}:${string}`;
 
 export type HubspotProperties = Record<string, string | null>;
 

--- a/src/lib/hubspot/manager.ts
+++ b/src/lib/hubspot/manager.ts
@@ -161,11 +161,11 @@ class Index<E extends Entity<any>> {
 
 }
 
-function mapObject<T, K extends keyof T, O>(o: T, fn: (e: T[K]) => O): { [K in keyof T]: O } {
+function mapObject<T extends Record<string, any>, K extends keyof T, O>(o: T, fn: (e: T[K]) => O): { [K in keyof T]: O } {
   const mapped = typedEntries(o).map(([k, v]) => [k, fn(v as T[K])]);
   return Object.fromEntries(mapped);
 }
 
-export function typedEntries<T, K extends keyof T, O>(o: T) {
+export function typedEntries<T extends Record<string, any>, K extends keyof T>(o: T) {
   return Object.entries(o) as [K, T[K]][];
 }

--- a/src/lib/hubspot/uploader.ts
+++ b/src/lib/hubspot/uploader.ts
@@ -24,7 +24,7 @@ export class HubspotUploader {
     await this.syncUpAllAssociations(hubspot.companyManager);
   }
 
-  private async syncUpAllEntitiesProperties<D, E extends Entity<D>>(manager: EntityManager<D, E>) {
+  private async syncUpAllEntitiesProperties<D extends Record<string, any>, E extends Entity<D>>(manager: EntityManager<D, E>) {
     const entitiesWithChanges = manager.getArray().map(e => ({ e, changes: e.getPropertyChanges() }));
     const toSync = entitiesWithChanges.filter(({ changes }) => Object.keys(changes).length > 0);
 
@@ -78,7 +78,7 @@ export class HubspotUploader {
     }
   }
 
-  private async syncUpAllAssociations<D, E extends Entity<D>>(manager: EntityManager<D, E>) {
+  private async syncUpAllAssociations<D extends Record<string, any>, E extends Entity<D>>(manager: EntityManager<D, E>) {
     const toSync = (manager.getArray()
       .filter(e => e.hasAssociationChanges())
       .flatMap(e => e.getAssociationChanges()

--- a/src/lib/log/download.ts
+++ b/src/lib/log/download.ts
@@ -23,7 +23,7 @@ export class MultiDownloadLogger {
   }
 
   private makeLine(name: string) {
-    let bar = this.multibar.create(1, 0, { name });
+    const bar = this.multibar.create(1, 0, { name });
     if (bar) return new AnimatedProgressBar(bar);
     return new SimpleLogProgress(this.console, name);
   }

--- a/src/lib/log/logdir.ts
+++ b/src/lib/log/logdir.ts
@@ -37,9 +37,9 @@ export class LogDir {
     return new HubspotOutputLogger(this.#hubspotResultLog);
   }
 
-  public allMatchGroupsLog() { return this.#allMatchGroupsLog?.writeCsvStream() };
-  public checkMatchGroupsLog() { return this.#checkMatchGroupsLog?.writeCsvStream() };
+  public allMatchGroupsLog() { return this.#allMatchGroupsLog?.writeCsvStream() }
+  public checkMatchGroupsLog() { return this.#checkMatchGroupsLog?.writeCsvStream() }
 
-  public attributionsLog() { return this.#attributionsLog };
+  public attributionsLog() { return this.#attributionsLog }
 
 }

--- a/src/lib/model/contact.ts
+++ b/src/lib/model/contact.ts
@@ -173,8 +173,8 @@ export class ContactManager extends EntityManager<ContactData, Contact> {
 
   public getByEmail = this.makeIndex(c => c.allEmails, ['email']);
 
-  constructor(config: HubspotContactConfig) {
-    super();
+  constructor(typeMappings: Map<string, string>, config: HubspotContactConfig) {
+    super(typeMappings);
     this.entityAdapter = makeAdapter(config);
   }
 

--- a/src/lib/model/deal.ts
+++ b/src/lib/model/deal.ts
@@ -312,8 +312,8 @@ export class DealManager extends EntityManager<DealData, Deal> {
 
   public duplicates = new Map<Deal, Deal[]>();
 
-  constructor(config: HubspotDealConfig) {
-    super();
+  constructor(typeMappings: Map<string, string>, config: HubspotDealConfig) {
+    super(typeMappings);
     this.entityAdapter = makeAdapter(config);
   }
 

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -105,10 +105,10 @@ export class Transaction extends MpacRecord<TransactionData> {
     if (tier === 'Unlimited Users') return 10001;
 
     let m;
-    if (m = tier.match(/^Per Unit Pricing \((\d+) users\)$/i)) {
+    if ((m = tier.match(/^Per Unit Pricing \((\d+) users\)$/i))) {
       return +m[1];
     }
-    if (m = tier.match(/^(\d+) Users$/)) {
+    if ((m = tier.match(/^(\d+) Users$/))) {
       return +m[1];
     }
 


### PR DESCRIPTION
For #142 

The previous implementation in #143 did not take into account that `contractor` could be on the `contact` side or the `company` side of such an association. This implementation also moves the logic to a more appropriate spot in the engine.