### PR TITLE
Fix HubSpot custom association support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,15 @@
         "<node_internals>/**"
       ],
       "type": "pwa-node"
+    },
+    {
+      "name": "Analyze Data Shift",
+      "program": "${workspaceFolder}/src/bin/analyze-data-shift.ts",
+      "request": "launch",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "type": "pwa-node"
     }
   ]
 }

--- a/src/lib/marketplace/api.ts
+++ b/src/lib/marketplace/api.ts
@@ -82,7 +82,7 @@ export class SingleMarketplaceAPI {
     });
 
     if (res.statusCode !== 200) {
-      throw new KnownError(`Marketpalce API: ${res.statusCode} ${res.statusMessage}`);
+      throw new KnownError(`Marketplace API: ${res.statusCode} ${res.statusMessage}`);
     }
 
     let text;

--- a/src/lib/marketplace/validation.ts
+++ b/src/lib/marketplace/validation.ts
@@ -107,10 +107,10 @@ export function assertRequiredTransactionFields(transaction: Transaction) {
   validateField(transaction, transaction => transaction.data.partnerDetails?.billingContact, o => !o || typeof o.email === 'string');
 }
 
-function validateField<T, V>(o: T, accessor: (o: T) => V, validator: (o: V) => boolean = o => !!o) {
+function validateField<T extends Transaction | License, V>(o: T, accessor: (o: T) => V, validator: (o: V) => boolean = o => !!o) {
   const val = accessor(o);
   const path = accessor.toString().replace(/^(\w+) => /, '');
-  if (!validator(val)) throw new AttachableError(`Missing field: ${path} (found ${JSON.stringify(val)})`, JSON.stringify(o, null, 2));
+  if (!validator(val)) throw new AttachableError(`Missing field (in ${o.id}): ${path} (found ${JSON.stringify(val)})`, JSON.stringify(o, null, 2));
 }
 
 export function hasTechEmail(license: License, console?: ConsoleLogger) {


### PR DESCRIPTION
This finishes #142 by updating data-shift-analysis code to support custom HubSpot association types. Previously stored data sets used a different association format than what we now use since #144, and the code wasn't able to support both formats. This PR supports both the old and new association formats in stored data sets, so that data-shift-analysis code will now work again.