### PR TITLE
fix-118 ignore same ID Licenses that are not strictly equal in valida…

### DIFF
--- a/src/lib/marketplace/marketplace.ts
+++ b/src/lib/marketplace/marketplace.ts
@@ -42,7 +42,7 @@ export class Marketplace {
     let transactions = data.transactions.map(raw => Transaction.fromRaw(raw));
 
     licenses = licenses.filter(l => validation.hasTechEmail(l, console));
-    licenses = validation.removeApiBorderDuplicates(licenses);
+    licenses = validation.removeApiBorderDuplicates(licenses, console);
 
     licenses.forEach(validation.assertRequiredLicenseFields);
     transactions.forEach(validation.assertRequiredTransactionFields);


### PR DESCRIPTION
The issue here is that someitmes, Licences can have their technical contact changed between runs, which causes the validation and run to fail due toduplicated deals being created. This change introduces a function that, in case there are two licenses with the same ID that are not strictly equal, will return the latest one by conmparing their License.data.lastUpdated value, and ignore the other License as a duplicatre.
Currently, the function will only print a warning stating the tweo Licenses considered 'different' and log the data for the one chosen as latest. Ideally we also want to notify of this event through slack, but that work is better suited to be done on issue #137 

