### PR TITLE
fix-158: ignore empty contact details when parsing licenses from AMP

### DIFF
--- a/src/lib/contact-generator/contact-generator.ts
+++ b/src/lib/contact-generator/contact-generator.ts
@@ -43,7 +43,7 @@ export class ContactGenerator {
 
   private associateContacts() {
     for (const record of [...this.licenses, ...this.transactions]) {
-      record.techContact = this.findContact(record.data.technicalContact.email)!;
+      record.techContact = this.findContact(record.data.technicalContact?.email)!;
       record.billingContact = this.findContact(record.data.billingContact?.email);
       record.partnerContact = this.findContact(record.data.partnerDetails?.billingContact.email);
 

--- a/src/lib/contact-generator/contact-types.ts
+++ b/src/lib/contact-generator/contact-types.ts
@@ -29,7 +29,7 @@ export class ContactTypeFlagger {
     for (const record of records) {
       maybeAddDomain(this.partnerDomains, record.data.partnerDetails?.billingContact.email);
       maybeAddDomain(this.customerDomains, record.data.billingContact?.email);
-      maybeAddDomain(this.customerDomains, record.data.technicalContact.email);
+      maybeAddDomain(this.customerDomains, record.data.technicalContact?.email);
     }
   }
 

--- a/src/lib/contact-generator/update-contacts.ts
+++ b/src/lib/contact-generator/update-contacts.ts
@@ -9,7 +9,7 @@ import { flagPartnersViaCoworkers } from "./contact-types";
 
 export function updateContactsBasedOnMatchResults(engine: Engine, allMatches: RelatedLicenseSet[]) {
   for (const license of allMatches) {
-    const contacts = new Set(license.map(license => engine.hubspot.contactManager.getByEmail(license.data.technicalContact.email)!));
+    const contacts = new Set(license.map(license => engine.hubspot.contactManager.getByEmail(license.data.technicalContact?.email || '')!));
 
     flagPartnersViaCoworkers([...contacts]);
 

--- a/src/lib/deal-generator/events.ts
+++ b/src/lib/deal-generator/events.ts
@@ -67,7 +67,7 @@ export class EventGenerator {
       return 'archived-app';
     }
 
-    const domains = new Set(records.map(license => license.data.technicalContact.email.toLowerCase().split('@')[1]));
+    const domains = new Set(records.map(license => license.data.technicalContact?.email.toLowerCase().split('@')[1] || ''));
     const partnerDomains = [...domains].filter(domain => this.partnerDomains.has(domain));
     const freeEmailDomains = [...domains].filter(domain => this.freeEmailDomains.has(domain));
 

--- a/src/lib/license-matching/license-grouper.ts
+++ b/src/lib/license-matching/license-grouper.ts
@@ -96,9 +96,9 @@ export class LicenseGrouper {
           companyDomain: this.freeEmailDomains.has(techContactDomain) ? '' : normalizeString(techContactDomain),
 
           techContactEmailPart,
-          techContactAddress: normalizeString(license.data.technicalContact.address1)?.toLowerCase(),
-          techContactName: normalizeString(license.data.technicalContact.name)?.toLowerCase(),
-          techContactPhone: normalizeString(license.data.technicalContact.phone)?.toLowerCase(),
+          techContactAddress: normalizeString(license.data.technicalContact?.address1)?.toLowerCase(),
+          techContactName: normalizeString(license.data.technicalContact?.name)?.toLowerCase(),
+          techContactPhone: normalizeString(license.data.technicalContact?.phone)?.toLowerCase(),
         },
       });
     }
@@ -172,15 +172,15 @@ export function shorterLicenseInfo(license: License) {
 
     company: license.data.company,
 
-    tech_email: license.data.technicalContact.email,
-    tech_name: license.data.technicalContact.name,
-    tech_address: license.data.technicalContact.address1,
-    tech_city: license.data.technicalContact.city,
-    tech_phone: license.data.technicalContact.phone,
-    tech_state: license.data.technicalContact.state,
-    tech_zip: license.data.technicalContact.postcode,
+    tech_email: license.data.technicalContact?.email,
+    tech_name: license.data.technicalContact?.name,
+    tech_address: license.data.technicalContact?.address1,
+    tech_city: license.data.technicalContact?.city,
+    tech_phone: license.data.technicalContact?.phone,
+    tech_state: license.data.technicalContact?.state,
+    tech_zip: license.data.technicalContact?.postcode,
     tech_country: license.data.country,
-    tech_address2: license.data.technicalContact.address2,
+    tech_address2: license.data.technicalContact?.address2,
 
     start: license.data.maintenanceStartDate,
     end: license.data.maintenanceEndDate,

--- a/src/lib/marketplace/marketplace.ts
+++ b/src/lib/marketplace/marketplace.ts
@@ -38,7 +38,7 @@ export class Marketplace {
       ...data.licensesWithoutDataInsights,
     ];
 
-    let licenses = combinedLicenses.map(raw => License.fromRaw(raw));
+    let licenses = combinedLicenses.map(raw => License.fromRaw(raw, console));
     let transactions = data.transactions.map(raw => Transaction.fromRaw(raw));
 
     licenses = licenses.filter(l => validation.hasTechEmail(l, console));

--- a/src/lib/marketplace/raw.ts
+++ b/src/lib/marketplace/raw.ts
@@ -1,3 +1,4 @@
+import { ConsoleLogger } from "../log/console";
 import { ContactInfo, PartnerInfo } from "../model/record";
 
 export type RawTransactionContact = {
@@ -119,8 +120,11 @@ export function getContactInfo(contactInfo: RawLicenseContact | RawTransactionCo
   };
 }
 
-export function maybeGetContactInfo(contactInfo: RawLicenseContact | RawTransactionContact | undefined): ContactInfo | null {
-  if (!contactInfo) return null;
+export function maybeGetContactInfo(contactInfo: RawLicenseContact | RawTransactionContact | undefined, console?: ConsoleLogger): ContactInfo | null {
+  if (!contactInfo) {
+    console?.printError('Marketplace Raw', 'Billing/Technical contact info missing, results may be affected. Check logs for potentially deleted deals');
+    return null;
+  }
   return getContactInfo(contactInfo);
 }
 
@@ -130,8 +134,8 @@ export function getPartnerInfo(info: RawPartnerDetails | undefined): PartnerInfo
     partnerName: info.partnerName,
     partnerType: info.partnerType,
     billingContact: {
-      email: info.billingContact.email,
-      name: info.billingContact.name,
+      email: info.billingContact?.email,
+      name: info.billingContact?.name,
     },
   };
 }

--- a/src/lib/marketplace/validation.ts
+++ b/src/lib/marketplace/validation.ts
@@ -85,7 +85,7 @@ export function assertRequiredLicenseFields(license: License) {
   validateField(license, license => license.data.country);
   validateField(license, license => license.data.region);
   validateField(license, license => license.data.technicalContact);
-  validateField(license, license => license.data.technicalContact.email);
+  validateField(license, license => license.data.technicalContact?.email);
   validateField(license, license => license.data.tier);
   validateField(license, license => license.data.licenseType);
   validateField(license, license => license.data.hosting);
@@ -104,7 +104,7 @@ export function assertRequiredTransactionFields(transaction: Transaction) {
   validateField(transaction, transaction => transaction.data.country);
   validateField(transaction, transaction => transaction.data.region);
   validateField(transaction, transaction => transaction.data.technicalContact);
-  validateField(transaction, transaction => transaction.data.technicalContact.email);
+  validateField(transaction, transaction => transaction.data.technicalContact?.email);
   validateField(transaction, transaction => transaction.data.saleDate);
   validateField(transaction, transaction => transaction.data.tier);
   validateField(transaction, transaction => transaction.data.licenseType);

--- a/src/lib/model/license.ts
+++ b/src/lib/model/license.ts
@@ -1,7 +1,8 @@
 import * as assert from 'assert';
-import { getContactInfo, getPartnerInfo, maybeGetContactInfo, RawLicense } from "../marketplace/raw";
+import { getPartnerInfo, maybeGetContactInfo, RawLicense } from "../marketplace/raw";
 import { ContactInfo, MpacRecord, PartnerInfo } from './record.js';
 import { Transaction } from './transaction';
+import { ConsoleLogger } from '../log/console';
 
 type AttributionData = {
   channel: string;
@@ -37,7 +38,7 @@ export interface LicenseData {
   addonName: string,
   lastUpdated: string,
 
-  technicalContact: ContactInfo,
+  technicalContact: ContactInfo | null,
   billingContact: ContactInfo | null,
   partnerDetails: PartnerInfo | null,
 
@@ -70,7 +71,7 @@ export class License extends MpacRecord<LicenseData> {
   public transactions: Transaction[] = [];
   public active: boolean;
 
-  static fromRaw(rawLicense: RawLicense) {
+  static fromRaw(rawLicense: RawLicense, console?: ConsoleLogger) {
     let newEvalData: NewEvalData | null = null;
     if (rawLicense.evaluationLicense) {
       newEvalData = {
@@ -105,8 +106,8 @@ export class License extends MpacRecord<LicenseData> {
       addonName: rawLicense.addonName,
       lastUpdated: rawLicense.lastUpdated,
 
-      technicalContact: getContactInfo(rawLicense.contactDetails.technicalContact),
-      billingContact: maybeGetContactInfo(rawLicense.contactDetails.billingContact),
+      technicalContact: maybeGetContactInfo(rawLicense.contactDetails.technicalContact, console),
+      billingContact: maybeGetContactInfo(rawLicense.contactDetails.billingContact, console),
       partnerDetails: getPartnerInfo(rawLicense.partnerDetails),
 
       company: rawLicense.contactDetails.company,

--- a/src/lib/model/record.ts
+++ b/src/lib/model/record.ts
@@ -43,7 +43,7 @@ export type PartnerInfo = {
 
 export function getEmailsForRecord(record: License | Transaction) {
   return [
-    record.data.technicalContact.email,
+    record.data.technicalContact?.email,
     record.data.billingContact?.email,
     record.data.partnerDetails?.billingContact.email,
   ].filter(isPresent);

--- a/src/lib/model/transaction.ts
+++ b/src/lib/model/transaction.ts
@@ -1,7 +1,8 @@
 import assert from "assert";
-import { getContactInfo, getPartnerInfo, maybeGetContactInfo, RawTransaction } from "../marketplace/raw";
+import { getPartnerInfo, maybeGetContactInfo, RawTransaction } from "../marketplace/raw";
 import { License } from "./license";
 import { ContactInfo, MpacRecord, PartnerInfo } from "./record";
+import { ConsoleLogger } from "../log/console";
 
 export interface TransactionData {
   addonLicenseId: string | null,
@@ -13,7 +14,7 @@ export interface TransactionData {
   addonName: string,
   lastUpdated: string,
 
-  technicalContact: ContactInfo,
+  technicalContact: ContactInfo | null,
   billingContact: ContactInfo | null,
   partnerDetails: PartnerInfo | null,
 
@@ -48,7 +49,7 @@ export class Transaction extends MpacRecord<TransactionData> {
   public license!: License;
   public refunded = false;
 
-  static fromRaw(rawTransaction: RawTransaction) {
+  static fromRaw(rawTransaction: RawTransaction, console?: ConsoleLogger) {
     return new Transaction({
       transactionId: rawTransaction.transactionId,
 
@@ -61,8 +62,8 @@ export class Transaction extends MpacRecord<TransactionData> {
       addonName: rawTransaction.addonName,
       lastUpdated: rawTransaction.lastUpdated,
 
-      technicalContact: getContactInfo(rawTransaction.customerDetails.technicalContact),
-      billingContact: maybeGetContactInfo(rawTransaction.customerDetails.billingContact),
+      technicalContact: maybeGetContactInfo(rawTransaction.customerDetails.technicalContact, console),
+      billingContact: maybeGetContactInfo(rawTransaction.customerDetails.billingContact, console),
       partnerDetails: getPartnerInfo(rawTransaction.partnerDetails),
 
       company: rawTransaction.customerDetails.company,


### PR DESCRIPTION
This change aims at ignoring empty tecvhnicalContact details from attlasian marketplace for transactions and licenses downloaded. Other fields seem to have been covered in regards to handling undefined values, but we might have to add more exemptions if other exceptions are found. For now, if thechnical contact is not present, empty values will be used instead, which might result in deals being deleted for not matching their technical contacts in case the data comes empty, much as the issue with RTBF data.
For now only logging as error and proceeding with execution, notification via slack can be done on #137 
Please let me know your thought @boris-moduscreate 
