### PR TITLE
Feat/invalid email mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 *.cpuprofile
 /out/
 .idea
+.npmrc
+.yarnrc

--- a/.sample.env
+++ b/.sample.env
@@ -30,6 +30,9 @@ IGNORED_APPS=com.mycompany.myapp1,com.mycompany.myapp2
 #   to be skipped when logging invalid MPAC transactions/licenses
 IGNORED_EMAILS=foo@bar,qux
 
+# Comma-separated list of email mapping to convert from MKP email to HubSpot email
+EMAIL_MAPPINGS=tom.cruise@topgun.coom=tom.cruise@topgun.coom
+
 HUBSPOT_PIPELINE_MPAC=1234567          # Hubspot Pipeline ID
 HUBSPOT_DEALSTAGE_EVAL=1234568         # Hubspot DealStage ID
 HUBSPOT_DEALSTAGE_CLOSED_WON=1234569   # Hubspot DealStage ID

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -108,6 +108,11 @@ export function hubspotContactConfigFromENV(): HubspotContactConfig {
 export function mpacConfigFromENV(): MpacConfig {
   return {
     ignoredEmails: new Set((optional('IGNORED_EMAILS')?.split(',') ?? []).map((e) => e.toLowerCase())),
+    emailMappings: optional('EMAIL_MAPPINGS')?.split(',').reduce((p: Record<string, string>, c: string) => {
+      let mapping = c.split('=')
+      p[mapping[0]] = mapping[1]
+      return p
+    }, {})
   };
 }
 

--- a/src/lib/engine/contacts/email-mapper.ts
+++ b/src/lib/engine/contacts/email-mapper.ts
@@ -1,0 +1,11 @@
+import { mpacConfigFromENV } from "../../config/env";
+
+export const mapEmail = (email: any) => {
+  if (email) {
+    let substitute = mpacConfigFromENV().emailMappings?.[email];
+    if (substitute) {
+      return substitute
+    }
+  }
+  return email
+}

--- a/src/lib/marketplace/marketplace.ts
+++ b/src/lib/marketplace/marketplace.ts
@@ -8,6 +8,7 @@ import * as validation from "./validation";
 
 export interface MpacConfig {
   ignoredEmails?: Set<string>;
+  emailMappings?: Record<string, string>
 }
 
 export class Marketplace {

--- a/src/lib/marketplace/raw.ts
+++ b/src/lib/marketplace/raw.ts
@@ -1,4 +1,5 @@
 import { ContactInfo, PartnerInfo } from "../model/record";
+import { mapEmail } from '../engine/contacts/email-mapper'
 
 export type RawTransactionContact = {
   email: string;
@@ -108,7 +109,7 @@ export interface RawLicense {
 
 export function getContactInfo(contactInfo: RawLicenseContact | RawTransactionContact): ContactInfo {
   return {
-    email: contactInfo.email,
+    email: mapEmail(contactInfo.email),
     name: contactInfo.name,
     ...('phone' in contactInfo && { phone: normalizeContactField(contactInfo.phone) }),
     ...('address1' in contactInfo && { address1: normalizeContactField(contactInfo.address1) }),
@@ -130,7 +131,7 @@ export function getPartnerInfo(info: RawPartnerDetails | undefined): PartnerInfo
     partnerName: info.partnerName,
     partnerType: info.partnerType,
     billingContact: {
-      email: info.billingContact.email,
+      email: mapEmail(info.billingContact.email),
       name: info.billingContact.name,
     },
   };

--- a/src/lib/util/helpers.ts
+++ b/src/lib/util/helpers.ts
@@ -4,7 +4,7 @@ export function isPresent<T>(o: T | undefined | null): o is T {
 
 export function batchesOf<T>(array: T[], count: number): T[][] {
   const tmp = [...array];
-  const batches = [];
+  const batches: T[][] = [];
   while (tmp.length) {
     batches.push(tmp.splice(0, count));
   }


### PR DESCRIPTION
We have records where use provided an invalid email address format in MPAC. (eg: firstname.lastname@domain.coom)

This PR propose a mapping capability to substitute mpac invalid email address with a fixed one which can be correctly imported into hubspot:
- firstname.lastname@domain.coom => firstname.lastname@domain.com