### PR TITLE
Add option to create contacts as non-marketing

### DIFF
--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -18,6 +18,10 @@ export function deleteBlockingDeals() {
   return optional('DELETE_BLOCKING_DEALS')?.toLowerCase() === 'yes';
 }
 
+export function createContactsAsNonMarketing() {
+  return optional('HUBSPOT_CREATE_CONTACTS_AS_NON_MARKETING')?.toLowerCase() === 'true';
+}
+
 export function hubspotCredsFromENV(): HubspotCreds {
   return {
     accessToken: required('HUBSPOT_ACCESS_TOKEN'),

--- a/src/lib/hubspot/uploader.ts
+++ b/src/lib/hubspot/uploader.ts
@@ -5,7 +5,7 @@ import { Hubspot } from './hubspot';
 import {EntityKind} from './interfaces';
 import { EntityManager, typedEntries } from "./manager";
 import {DealManager} from '../model/deal'
-import {deleteBlockingDeals} from '../config/env'
+import {createContactsAsNonMarketing, deleteBlockingDeals} from '../config/env'
 
 export class HubspotUploader {
 
@@ -44,10 +44,14 @@ export class HubspotUploader {
     const toUpdate = toSync.filter(({ e }) => e.id !== null);
 
     if (toCreate.length > 0) {
+      const nonMarketingProps: Record<string, string> = (manager.entityAdapter.kind === 'contact' && createContactsAsNonMarketing())
+        ? { hs_marketable_status: 'false' }
+        : {};
+
       const created = await this.api.createEntities(
         manager.entityAdapter.kind,
         toCreate.map(({ changes }) => ({
-          properties: changes as Record<string, string>,
+          properties: { ...nonMarketingProps, ...changes as Record<string, string> },
         }))
       );
 


### PR DESCRIPTION
## Summary
- When `HUBSPOT_CREATE_CONTACTS_AS_NON_MARKETING=true`, newly created contacts are sent with `hs_marketable_status: false` so they don't count toward the HubSpot marketing contacts billing tier.
- Disabled by default — no behavior change unless the env var is explicitly set.

## Changes
- `src/lib/config/env.ts`: New `createContactsAsNonMarketing()` helper reading the env var
- `src/lib/hubspot/uploader.ts`: Injects `hs_marketable_status` into contact properties at creation time when enabled

## Note
Requires the **Marketing Contacts** feature to be enabled on the HubSpot portal. If not enabled, the `hs_marketable_status` property won't exist and HubSpot may ignore it or error.

## Test plan
- [ ] Set `HUBSPOT_CREATE_CONTACTS_AS_NON_MARKETING=true` and run a sync cycle — verify new contacts appear as non-marketing in HubSpot
- [ ] Without the env var (or set to anything other than `true`) — verify contacts are created with default marketing status (no change in behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)